### PR TITLE
fix: publish 1.0.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,5 +8,4 @@ RUN apt-get update && \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
 ENV PATH "${PATH}:root/.guard/bin"
 
-
 COPY ./output/ /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
-ENV PATH "${PATH}:~/.guard/bin"
+ENV PATH "${PATH}:root/.guard/bin"
+
 
 COPY ./output/ /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
-ENV PATH "${PATH}:root/.guard/bin"
+ENV PATH "${PATH}:/root/.guard/bin"
 
 COPY ./output/ /

--- a/docs/Using-Guard-Rules-Registry.md
+++ b/docs/Using-Guard-Rules-Registry.md
@@ -54,15 +54,15 @@ cfn-guard validate --rules ./NIST800-53Rev4.guard --data myCloudFormation.yml --
 
 All AWS Guard Rule Registry are build into a Docker image with Guard installed. The release rule set files are built and copied into the Docker image allowing for simplified rule set specific. Follow these steps to pull the Docker image and view the available rule sets.
 
-1. run: `docker pull public.ecr.aws/r7q6h7y6/guard:1.0.0`
+1. run: `docker pull public.ecr.aws/r7q6h7y6/guard:1.0.1`
 2. enter the container to view available rules:
   ```
-  docker run -it public.ecr.aws/r7q6h7y6/guard:1.0.0 sh
+  docker run -it public.ecr.aws/r7q6h7y6/guard:1.0.1 sh
   ls
   ```
 3. all rule sets are built into the root directory
 
-> **Note:** The Docker image version identifies the release version. Using the latest tag will give you the latest release.
+> **Note:** The Docker image version identifies the release version. Using the `latest` tag will give you the latest release.
 
 ## AWS CodePipeline
 
@@ -79,7 +79,7 @@ Gitlab-CI can leverage the AWS Guard Rules Registry docker image. The example be
 ```yml
 image:
   repository: public.ecr.aws/r7q6h7y6/guard
-  tag: 1.0.0
+  tag: 1.0.1
 
 stages:
  - ci


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Publish Docker image 1.0.1 with env path fix for cfn-guard install

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
