### PR TITLE
feat: Make docker image work with non-root users

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
-ENV PATH "${PATH}:root/.guard/bin"
+# /opt/guard/bin/cfn-guard is a softlink, so we deference it. We don't need other files that way (so no -r)
+RUN mkdir -p "/opt/bin" && cp --dereference "/root/.guard/bin/cfn-guard" "/opt/bin/"
+ENV PATH "${PATH}:/opt/bin"
 
 COPY ./output/ /


### PR DESCRIPTION
*Issue #, if available:*
#217

*Description of changes:*
This copies the guard binary to /opt (instead of using a symlink that points to a file in the /root folder)

Running cfn-guard will now work even if you're not running as root in the container

```
# after running docker build -t guard:local . in the docker folder
~$ docker run -it guard:local which cfn-guard
/opt/bin/cfn-guard
~$ docker run -u 501 -it guard:local cfn-guard --version
cfn-guard 2.1.0
~$ docker run -u 501 -it guard:local which cfn-guard
/opt/bin/cfn-guard
~$ docker run -u 501 -it guard:local cfn-guard --version
cfn-guard 2.1.0
```

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
