### PR TITLE
feat(rules): add (limited) deprecation rules

### DIFF
--- a/mappings/rule_set_community-deprecations.json
+++ b/mappings/rule_set_community-deprecations.json
@@ -1,0 +1,13 @@
+{
+  "owner": "Guard Community",
+  "ruleSetName": "community-deprectaions",
+  "version": "0.0.1",
+  "description": "AWS Guard rule set to track deprecations",
+  "contact": "aws-guard-rules-registry@amazon.com",
+  "mappings": [
+    {
+      "guardFilePath": "rules/aws/cloudfront/cloudfront_origin_access_identity_deprecated.guard",
+      "controls": []
+    }
+  ]
+}

--- a/rules/aws/cloudfront/cloudfront_origin_access_identity_deprecated.guard
+++ b/rules/aws/cloudfront/cloudfront_origin_access_identity_deprecated.guard
@@ -1,0 +1,52 @@
+#
+#####################################
+##           Gherkin               ##
+#####################################
+# Rule Identifier:
+#    CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED
+#
+# Description:
+#  Checks if Amazon CloudFront distributions use the deprecated Origin Access Identity (OAI).
+#
+# Reports on:
+#    AWS::CloudFront::Distribution
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# Scenarios:
+# a) SKIP: when there are no CloudFront Distribution Resources
+# b) SKIP: when metadata has rule suppression for CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED
+# c) FAIL: when CloudFront Distribution Resources have a Legacy S3 Origin configuration with Origin Access Identity (OAI)
+# d) FAIL: when CloudFront Distribution Resources have an Origin configured with an Origin Access Identity (OAI)
+# e) PASS: when CloudFront Distribution Resources do not have an OAI configured
+
+#
+# Select all CloudFront Distribution Resources from incoming template (payload)
+#
+let cloudfront_distribution_resources = Resources.*[ Type == 'AWS::CloudFront::Distribution'
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED"
+]
+
+rule CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED when %cloudfront_distribution_resources !empty {
+  let legacy_violations = %cloudfront_distribution_resources[
+    Properties.DistributionConfig.S3Origin.OriginAccessIdentity exists
+  ]
+  let violations = %cloudfront_distribution_resources.Properties.DistributionConfig.Origins.[
+    S3OriginConfig.OriginAccessIdentity exists
+  ]
+  %legacy_violations empty
+  <<
+    Violation: CloudFront Distributions should use Origin Access Control instead of Origin Access Identity (OAI).
+    Fix: Replace the S3Origin.OriginAccessIdentity property with Origins[].OriginAccessControlId for CloudFront Distribution Origins backed by S3.
+  >>
+  %violations empty
+  <<
+    Violation: CloudFront Distributions should use Origin Access Control instead of Origin Access Identity (OAI).
+    Fix: Replace the S3OriginConfig.OriginAccessIdentity property with OriginAccessControlId for CloudFront Distribution Origins backed by S3.
+  >>
+}

--- a/rules/aws/cloudfront/cloudfront_origin_access_identity_enabled.guard
+++ b/rules/aws/cloudfront/cloudfront_origin_access_identity_enabled.guard
@@ -24,6 +24,7 @@
 # d) FAIL: when CloudFront Distribution Resources have an S3 Origin configured without an Origin Access Identity (OAI)
 # e) PASS: when CloudFront Distribution Resources do not have an S3 Origin configured
 # f) PASS: when CloudFront Distribution Resources have an S3 Origin configured with an Origin Access Identity (OAI)
+# g) PASS: when CloudFront Distribution Resources have an S3 Origin configured with a Origin Access Control
 
 #
 # Select all CloudFront Distribution Resources from incoming template (payload)
@@ -36,8 +37,8 @@ let cloudfront_origin_access_identity_enabled_resources = Resources.*[ Type == '
 rule CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED when %cloudfront_origin_access_identity_enabled_resources !empty {
   let violations = %cloudfront_origin_access_identity_enabled_resources.Properties.DistributionConfig.Origins.[
     DomainName == /[a-z0-9\.-]{3,63}\.s3\.amazonaws\.com/
-    S3OriginConfig.OriginAccessIdentity !exists or
-    S3OriginConfig.OriginAccessIdentity == ""
+    S3OriginConfig.OriginAccessIdentity !exists or S3OriginConfig.OriginAccessIdentity == ""
+    OriginAccessControlId !exists or OriginAccessControlId == ""
   ]
   %violations empty
   <<

--- a/rules/aws/cloudfront/tests/cloudfront_origin_access_identity_deprecated_tests.yml
+++ b/rules/aws/cloudfront/tests/cloudfront_origin_access_identity_deprecated_tests.yml
@@ -1,0 +1,144 @@
+###
+# CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: SKIP
+
+- name: Scenario a) No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: SKIP
+
+- name: Scenario b) Rule suppressed, SKIP
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Metadata:
+          guard:
+            SuppressedRules:
+              - "CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED"
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: SKIP
+
+- name: Scenario c) 'S3Origin.OriginAccessIdentity' exists on the CloudFront Distribution, FAIL
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            S3Origin:
+              OriginAccessIdentity: origin-access-identity/cloudfront/E127EXAMPLE51Z
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: FAIL
+
+- name: Scenario d) 'Origins' has a configured S3 origin (global endpoint) with an OAI configuration, FAIL
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName: mybucket.s3.amazonaws.com
+                Id: myS3Origin
+                S3OriginConfig:
+                  OriginAccessIdentity: origin-access-identity/cloudfront/E127EXAMPLE51Z
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: FAIL
+
+- name: Scenario d) 'Origins' has a configured S3 origin (regional endpoint) with an OAI configuration, FAIL
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName: mybucket.s3.ap-southeast-2.amazonaws.com
+                Id: myS3Origin
+                S3OriginConfig:
+                  OriginAccessIdentity: origin-access-identity/cloudfront/E127EXAMPLE51Z
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: FAIL
+
+- name: Scenario e) 'Origins' has an S3 origin (global endpoint) configured without an 'S3OriginConfig.OriginAccessIdentity', PASS
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName: mybucket.s3.amazonaws.com
+                Id: myGlobalEndpointS3Origin
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: PASS
+
+- name: Scenario e) 'Origins' has an S3 origin (regional endpoint) configured without an 'S3OriginConfig.OriginAccessIdentity', PASS
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName: mybucket.s3.ap-southeast-2.amazonaws.com
+                Id: myRegionalEndpointS3Origin
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: PASS
+
+- name: Scenario e) 'Origins' has not been provided, PASS
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig: {}
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: PASS
+
+- name: Scenario e) 'Origins' has no configured S3 origins (empty list), PASS
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins: []
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: PASS
+
+- name: Scenario e) 'Origins' has no configured S3 origins (custom origin), PASS
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName: mycustomorigin.com
+                Id: myCustomOrigin
+                CustomOriginConfig:
+                  HTTPSPort: 443
+                  OriginProtocolPolicy: match-viewer
+                  OriginSSLProtocols:
+                    - TLSv1.2
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_DEPRECATED: PASS

--- a/rules/aws/cloudfront/tests/cloudfront_origin_access_identity_enabled_tests.yml
+++ b/rules/aws/cloudfront/tests/cloudfront_origin_access_identity_enabled_tests.yml
@@ -142,3 +142,33 @@
   expectations:
     rules:
       CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: PASS
+
+- name: Scenario g) 'Origins' has a configured S3 origin (global endpoint) with an OAC configuration, PASS
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName: mybucket.s3.amazonaws.com
+                Id: myS3Origin
+                OriginAccessControlId: oac-id
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: PASS
+
+- name: Scenario f) 'Origins' has a configured S3 origin (regional endpoint) with an OAI configuration, PASS
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName: mybucket.s3.ap-southeast-2.amazonaws.com
+                Id: myS3Origin
+                OriginAccessControlId: oac-id
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: PASS


### PR DESCRIPTION
- Allow Origin Access Control in addition to Origin Access Identity
- Add rule for Origin Access Identity deprecation


Submitting as draft, because I'm having trouble running tests locally (even on the main branch)

```
cfn-guard test --rules-file rules/aws/cloudfront/cloudfront_origin_access_identity_enabled.guard --test-data rules/aws/cloudfront/tests/cloudfront_origin_access_identity_enabled_tests.yml
Parse Error on ruleset file Parser Error when parsing Parsing Error Error parsing file rules/aws/cloudfront/cloudfront_origin_access_identity_enabled.guard at line 37 at column 110, when handling , fragment .[
    DomainName == /[a-z0-9\.-]{3,63}\.s3\.amazonaws\.com/
    S3OriginConfig.OriginAccessIdentity !exists or
    S3OriginConfig.OriginAccessIdentity == ""
  ]
  %violations empty
  <<
    Violation: CloudFront Distributions backed by S3 must be configured with an Origin Access Identity (OAI).
    Fix: Set the S3OriginConfig.OriginAccessIdentity property for CloudFront Distribution Origins backed by S3.
  >>
}
```
---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
