### PR TITLE
fix: resources in iam policies can be lists

### DIFF
--- a/rules/aws/iam/iam_policy_no_statements_with_admin_access.guard
+++ b/rules/aws/iam/iam_policy_no_statements_with_admin_access.guard
@@ -37,7 +37,7 @@ rule IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS when %aws_iam_policies_no_statem
     some Properties.PolicyDocument.Statement[*] {
       some Action[*] == "*"
       Effect == "Allow"
-      Resource == "*"
+      some Resource in ["*"]
     }
   ]
   %violations empty

--- a/rules/aws/iam/iam_policy_no_statements_with_full_access.guard
+++ b/rules/aws/iam/iam_policy_no_statements_with_full_access.guard
@@ -37,7 +37,7 @@ rule IAM_POLICY_NO_STATEMENTS_WITH_FULL_ACCESS when %aws_iam_managed_policies_no
     some Properties.PolicyDocument.Statement[*] {
       some Action[*] in ["*", /^[a-zA-Z0-9]*:\*$/]
       Effect == "Allow"
-      Resource == "*"
+      some Resource in ["*"]
     }
   ]
   %violations empty

--- a/rules/aws/iam/tests/iam_policy_no_statements_with_admin_access_tests.yml
+++ b/rules/aws/iam/tests/iam_policy_no_statements_with_admin_access_tests.yml
@@ -34,6 +34,26 @@
     rules: 
       IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS: PASS
 
+- name: IAM Policy with S3 read only access statement and resource list, PASS
+  input:
+    Resources:
+      ExamplePolicy:
+        Type: AWS::IAM::Policy
+        Properties:
+          Policy Name: "S3ReadOnly"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: 
+                  - "s3:Get*"
+                  - "s3:List*"
+                Resource:
+                  - "*"
+  expectations:
+    rules: 
+      IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS: PASS
+
 - name: IAM Policy with S3 full access statement, PASS
   input: 
     Resources: 
@@ -66,6 +86,24 @@
                 Resource: "*"
   expectations:
     rules: 
+      IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS: FAIL
+
+- name: IAM Policy with "Allow" statement granting permissions to all actions on all resources as a list, FAIL 
+  input:
+    Resources:
+      ExamplePolicy:
+        Type: AWS::IAM::Policy
+        Properties:
+          Policy Name: "Admin"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: "*"
+                Resource:
+                  - "*"
+  expectations:
+    rules:
       IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS: FAIL
 
 - name: IAM Policy with "Allow" statement granting permissions to all actions on all resources but rule suppressed, SKIP

--- a/rules/aws/iam/tests/iam_policy_no_statements_with_full_access_tests.yml
+++ b/rules/aws/iam/tests/iam_policy_no_statements_with_full_access_tests.yml
@@ -31,6 +31,23 @@
     rules: 
       IAM_POLICY_NO_STATEMENTS_WITH_FULL_ACCESS: PASS
 
+- name: IAM Managed Policy with only "Deny" S3 saccess statement and resource list, PASS
+  input:
+    Resources:
+      ExamplePolicy:
+        Type: "AWS::IAM::ManagedPolicy"
+        Properties:
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Deny"
+                Action: "s3:*"
+                Resource:
+                  - "*"
+  expectations:
+    rules:
+      IAM_POLICY_NO_STATEMENTS_WITH_FULL_ACCESS: PASS
+
 - name: IAM Managed Policy with S3 read only access statement, PASS
   input: 
     Resources: 
@@ -74,6 +91,31 @@
                 Resource: "*"
   expectations:
     rules: 
+      IAM_POLICY_NO_STATEMENTS_WITH_FULL_ACCESS: FAIL
+
+
+- name: IAM Managed Policy with S3 full access statement and resource list, FAIL
+  input:
+    Resources:
+      ExamplePolicy:
+        Type: "AWS::IAM::ManagedPolicy"
+        Properties:
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Deny"
+                Action: "ec2:*"
+                Resource: "*"
+              - Effect: "Allow"
+                Action:
+                  - "iam:Get*"
+                  - "iam:List*"
+                Resource: "*"
+              - Effect: "Allow"
+                Action: "s3:*"
+                Resource: "*"
+  expectations:
+    rules:
       IAM_POLICY_NO_STATEMENTS_WITH_FULL_ACCESS: FAIL
 
 - name: IAM Managed Policy with "Allow" statement granting permissions to all actions on all resources, FAIL 


### PR DESCRIPTION
Ran into this while testing template scanning, guard failed when I had `Resource: ['a', 'b']

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
