### PR TITLE
fix: rule syntax incompatibilities for use with guard v2.1.3

### DIFF
--- a/rules/aws/cloudfront/cloudfront_origin_access_identity_enabled.guard
+++ b/rules/aws/cloudfront/cloudfront_origin_access_identity_enabled.guard
@@ -34,14 +34,42 @@ let cloudfront_origin_access_identity_enabled_resources = Resources.*[ Type == '
 ]
 
 rule CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED when %cloudfront_origin_access_identity_enabled_resources !empty {
-  let violations = %cloudfront_origin_access_identity_enabled_resources.Properties.DistributionConfig.Origins.[
-    DomainName == /[a-z0-9\.-]{3,63}\.s3\.amazonaws\.com/
-    S3OriginConfig.OriginAccessIdentity !exists or
-    S3OriginConfig.OriginAccessIdentity == ""
-  ]
-  %violations empty
-  <<
-    Violation: CloudFront Distributions backed by S3 must be configured with an Origin Access Identity (OAI).
-    Fix: Set the S3OriginConfig.OriginAccessIdentity property for CloudFront Distribution Origins backed by S3.
-  >>
+  let doc = this  
+  %cloudfront_origin_access_identity_enabled_resources.Properties.DistributionConfig {
+    S3Origin not exists
+
+    when Origins exists
+         Origins is_list
+         Origins not empty {
+
+      Origins [
+        DomainName == /(.*)\.s3(-external-\d|[-\.][a-z]*-[a-z]*-[0-9])?\.amazonaws\.com(\.cn)?$/ or
+        DomainName {
+          'Fn::GetAtt' {
+              this is_list
+              this[1] == "DomainName" or
+              this[1] == "RegionalDomainName"
+              
+              let resource_logical_name = this[0]
+              let referenced_resource = %doc.Resources[ keys == %resource_logical_name ]            
+              
+              %referenced_resource not empty
+              %referenced_resource {
+                  Type == "AWS::S3::Bucket"    
+              }
+          }
+        }
+      ] {
+        S3OriginConfig.OriginAccessIdentity exists
+        S3OriginConfig.OriginAccessIdentity != ""
+        
+        S3OriginConfig.OriginAccessIdentity is_string or 
+        S3OriginConfig.OriginAccessIdentity is_struct
+        <<
+          Violation: CloudFront Distributions backed by S3 must be configured with an Origin Access Identity (OAI).
+          Fix: Set the S3OriginConfig.OriginAccessIdentity property for CloudFront Distribution Origins backed by S3.
+        >>
+      }
+    }
+  } 
 }

--- a/rules/aws/cloudfront/tests/cloudfront_origin_access_identity_enabled_tests.yml
+++ b/rules/aws/cloudfront/tests/cloudfront_origin_access_identity_enabled_tests.yml
@@ -36,7 +36,7 @@
         Properties:
           DistributionConfig:
             S3Origin:
-                DNSName: my-bucket.s3.ap-southeast-2.amazonaws.com
+              DNSName: my-bucket.s3.ap-southeast-2.amazonaws.com
   expectations:
     rules:
       CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: FAIL
@@ -55,6 +55,25 @@
     rules:
       CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: FAIL
 
+- name: Scenario d) 'Origins' has an S3 origin (global endpoint) configured without an 'S3OriginConfig.OriginAccessIdentity', FAIL
+  input:
+    Resources:
+      OriginBucket:
+        Type: AWS::S3::Bucket
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName:
+                  Fn::GetAtt:
+                    - OriginBucket
+                    - DomainName
+                Id: myS3Origin
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: FAIL
+
 - name: Scenario d) 'Origins' has an S3 origin (regional endpoint) configured without an 'S3OriginConfig.OriginAccessIdentity', FAIL
   input:
     Resources:
@@ -65,6 +84,25 @@
             Origins:
               - DomainName: mybucket.s3.ap-southeast-2.amazonaws.com
                 Id: myRegionalEndpointS3Origin
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: FAIL
+
+- name: Scenario d) 'Origins' has an S3 origin (regional endpoint) configured without an 'S3OriginConfig.OriginAccessIdentity', FAIL
+  input:
+    Resources:
+      OriginBucket:
+        Type: AWS::S3::Bucket
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName:
+                  Fn::GetAtt:
+                    - OriginBucket
+                    - RegionalDomainName
+                Id: myS3Origin
   expectations:
     rules:
       CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: FAIL
@@ -127,6 +165,27 @@
     rules:
       CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: PASS
 
+- name: Scenario f) 'Origins' has a configured S3 origin (global endpoint) with an OAI configuration, PASS
+  input:
+    Resources:
+      OriginBucket:
+        Type: AWS::S3::Bucket
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName:
+                  Fn::GetAtt:
+                    - OriginBucket
+                    - DomainName
+                Id: myS3Origin
+                S3OriginConfig:
+                  OriginAccessIdentity: origin-access-identity/cloudfront/E127EXAMPLE51Z
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: PASS
+
 - name: Scenario f) 'Origins' has a configured S3 origin (regional endpoint) with an OAI configuration, PASS
   input:
     Resources:
@@ -136,6 +195,27 @@
           DistributionConfig:
             Origins:
               - DomainName: mybucket.s3.ap-southeast-2.amazonaws.com
+                Id: myS3Origin
+                S3OriginConfig:
+                  OriginAccessIdentity: origin-access-identity/cloudfront/E127EXAMPLE51Z
+  expectations:
+    rules:
+      CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED: PASS
+
+- name: Scenario f) 'Origins' has a configured S3 origin (regional endpoint) with an OAI configuration, PASS
+  input:
+    Resources:
+      OriginBucket:
+        Type: AWS::S3::Bucket
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            Origins:
+              - DomainName:
+                  Fn::GetAtt:
+                    - OriginBucket
+                    - RegionalDomainName
                 Id: myS3Origin
                 S3OriginConfig:
                   OriginAccessIdentity: origin-access-identity/cloudfront/E127EXAMPLE51Z

--- a/rules/aws/elastic_load_balancing/elb_acm_certificate_required.guard
+++ b/rules/aws/elastic_load_balancing/elb_acm_certificate_required.guard
@@ -25,7 +25,8 @@
 # a) SKIP: when there are no Elastic Load Balancing Resources
 # b) SKIP: when metadata has rule suppression for ELB_ACM_CERTIFICATE_REQUIRED
 # c) SKIP: when there are no HTTPS or SSL 'Listeners'
-# d) PASS: when 'SSLCertificateId' matches an ACM certificate ARN for all HTTPS and SSL 'Listeners'
+# d) FAIL: when 'SSLCertificateId' does not matches an ACM certificate ARN for all HTTPS and SSL 'Listeners'
+# e) PASS: when 'SSLCertificateId' matches an ACM certificate ARN for all HTTPS and SSL 'Listeners'
 
 #
 # Select all Elastic Load Balancing Resources from incoming template (payload)
@@ -36,19 +37,28 @@ let elb_acm_certificate_required_resources = Resources.*[ Type == 'AWS::ElasticL
 ]
 
 rule ELB_ACM_CERTIFICATE_REQUIRED when %elb_acm_certificate_required_resources !empty {
+    let doc = this
     %elb_acm_certificate_required_resources.Properties {
-        let https_ssl_listeners = Listeners.[
+        Listeners[
+            # Scenario c)
             Protocol in ['HTTPS', 'SSL']
-        ]
-
-        when %https_ssl_listeners not empty {
-            %https_ssl_listeners {
-                # Scenarios c) and d)
-                SSLCertificateId exists
-                <<
-                    Violation: Classic Load Balancer Listeners need to use HTTPS/SSL certificates provided by AWS Certificate Manager (ACM).
-                    Fix: Set the Classic Load Balancer Listeners.*.SSLCertificateId property to the ARN of an ACM Certificate.
-                >>
+        ] {
+            # Scenarios d) and e)
+            SSLCertificateId exists
+            SSLCertificateId == /arn:aws[a-z0-9\-]*:acm:[a-z0-9\-]+:\d{12}:certificate\/[\w\-]{1,64}/ or 
+            SSLCertificateId {
+                Ref {
+                    let resource_logical_name = this
+                    let referenced_resource = %doc.Resources[ keys == %resource_logical_name ]
+                    %referenced_resource not empty
+                    %referenced_resource {
+                        Type == "AWS::CertificateManager::Certificate"
+                        <<
+                            Violation: Classic Load Balancer Listeners need to use HTTPS/SSL certificates provided by AWS Certificate Manager (ACM).
+                            Fix: Set the Classic Load Balancer Listeners.*.SSLCertificateId property to the ARN of an ACM Certificate.
+                        >>    
+                    }
+                }
             }
         }
     }

--- a/rules/aws/elastic_load_balancing/tests/elb_acm_certificate_required_tests.yml
+++ b/rules/aws/elastic_load_balancing/tests/elb_acm_certificate_required_tests.yml
@@ -53,6 +53,31 @@
     rules:
       ELB_ACM_CERTIFICATE_REQUIRED: SKIP
 
+- name: Scenario d) 'SSLCertificateId' does not match an ACM certificate ARN for all 'Listeners' (HTTPS), PASS
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+            - Protocol: HTTPS
+              SSLCertificateId: arn:aws:iam::123456789012:server-certificate/example-certificate
+  expectations:
+    rules:
+      ELB_ACM_CERTIFICATE_REQUIRED: FAIL
+
+- name: Scenario d) 'SSLCertificateId' does not match an ACM certificate ARN for all 'Listeners' (SSL), PASS
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+            - Protocol: SSL
+              SSLCertificateId: arn:aws:iam::123456789012:server-certificate/example-certificate
+  expectations:
+    rules:
+      ELB_ACM_CERTIFICATE_REQUIRED: FAIL
 
 - name: Scenario e) 'SSLCertificateId' matches an ACM certificate ARN for all 'Listeners' (HTTPS), PASS
   input:
@@ -67,6 +92,21 @@
     rules:
       ELB_ACM_CERTIFICATE_REQUIRED: PASS
 
+- name: Scenario e) 'SSLCertificateId' matches an ACM certificate ARN for all 'Listeners' (HTTPS), PASS
+  input:
+    Resources:
+      ACMCertificate:
+        Type: AWS::CertificateManager::Certificate
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+            - Protocol: HTTPS
+              SSLCertificateId:
+                Ref: ACMCertificate
+  expectations:
+    rules:
+      ELB_ACM_CERTIFICATE_REQUIRED: PASS
 
 - name: Scenario e) 'SSLCertificateId' matches an ACM certificate ARN for all 'Listeners' (SSL), PASS
   input:
@@ -81,6 +121,22 @@
     rules:
       ELB_ACM_CERTIFICATE_REQUIRED: PASS
 
+- name: Scenario e) 'SSLCertificateId' matches an ACM certificate ARN for all 'Listeners' (SSL), PASS
+  input:
+    Resources:
+      ACMCertificate:
+        Type: AWS::CertificateManager::Certificate
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+            - Protocol: HTTPS
+              SSLCertificateId:
+                Ref: ACMCertificate
+  expectations:
+    rules:
+      ELB_ACM_CERTIFICATE_REQUIRED: PASS
+
 - name: Scenario e) 'SSLCertificateId' matches an ACM certificate ARN for all 'Listeners' (HTTPS & SSL), PASS
   input:
     Resources:
@@ -90,6 +146,43 @@
           Listeners:
             - Protocol: HTTPS
               SSLCertificateId: arn:aws:acm:us-west-2:123456789012:certificate/12345678-12ab-34cd-56ef-12345678
+            - Protocol: SSL
+              SSLCertificateId: arn:aws:acm:us-west-2:123456789012:certificate/12345678-12ab-34cd-56ef-12345678
+  expectations:
+    rules:
+      ELB_ACM_CERTIFICATE_REQUIRED: PASS
+
+- name: Scenario e) 'SSLCertificateId' matches an ACM certificate ARN for all 'Listeners' (HTTPS & SSL), PASS
+  input:
+    Resources:
+      ACMCertificate:
+        Type: AWS::CertificateManager::Certificate
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+            - Protocol: HTTPS
+              SSLCertificateId:
+                Ref: ACMCertificate
+            - Protocol: SSL
+              SSLCertificateId:
+                Ref: ACMCertificate
+  expectations:
+    rules:
+      ELB_ACM_CERTIFICATE_REQUIRED: PASS
+
+- name: Scenario e) 'SSLCertificateId' matches an ACM certificate ARN for all 'Listeners' (HTTPS & SSL), PASS
+  input:
+    Resources:
+      ACMCertificate:
+        Type: AWS::CertificateManager::Certificate
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+            - Protocol: HTTPS
+              SSLCertificateId:
+                Ref: ACMCertificate
             - Protocol: SSL
               SSLCertificateId: arn:aws:acm:us-west-2:123456789012:certificate/12345678-12ab-34cd-56ef-12345678
   expectations:

--- a/rules/aws/elastic_load_balancing_v2/alb_http_drop_invalid_header_enabled.guard
+++ b/rules/aws/elastic_load_balancing_v2/alb_http_drop_invalid_header_enabled.guard
@@ -30,25 +30,24 @@
 # Select all Elastic Load Balancing V2 Resources from incoming template of type 'application' (payload)
 #
 let alb_http_drop_invalid_header_enabled_resources = Resources.*[ Type == 'AWS::ElasticLoadBalancingV2::LoadBalancer'
-  Properties.Type == 'application'
+  Properties.Type == "application"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "ALB_HTTP_DROP_INVALID_HEADER_ENABLED"
 ]
 
 rule ALB_HTTP_DROP_INVALID_HEADER_ENABLED when %alb_http_drop_invalid_header_enabled_resources !empty {
-    %alb_http_drop_invalid_header_enabled_resources {
-        Properties {
-			LoadBalancerAttributes exists
-			when LoadBalancerAttributes exists {
-				some LoadBalancerAttributes[*] {
-					Key == "deletion_protection.enabled"
-					Value == true
-				}
-			}
-		}
-        <<
-            Violation: AWS Application Load Balancers (ALB) must be configured to drop invalid HTTP headers.
-            Fix: Set the 'LoadBalancerAttribute' 'routing.http.drop_invalid_header_fields.enabled' to 'true'
-        >>
+    %alb_http_drop_invalid_header_enabled_resources.Properties {
+        LoadBalancerAttributes exists
+        LoadBalancerAttributes is_list
+        LoadBalancerAttributes not empty
+        
+        some LoadBalancerAttributes[*] {
+            Key == "routing.http.drop_invalid_header_fields.enabled"
+            Value == true
+            <<
+                Violation: AWS Application Load Balancers (ALB) must be configured to drop invalid HTTP headers.
+                Fix: Set the 'LoadBalancerAttribute' 'routing.http.drop_invalid_header_fields.enabled' to 'true'
+            >>
+        }	
     }
 }

--- a/rules/aws/elastic_load_balancing_v2/elb_deletion_protection_enabled.guard
+++ b/rules/aws/elastic_load_balancing_v2/elb_deletion_protection_enabled.guard
@@ -35,19 +35,18 @@ let elb_deletion_protection_enabled_resources = Resources.*[ Type == 'AWS::Elast
 ]
 
 rule ELB_DELETION_PROTECTION_ENABLED when %elb_deletion_protection_enabled_resources !empty {
-    %elb_deletion_protection_enabled_resources {
-        Properties {
-        # Scenario c)
+    %elb_deletion_protection_enabled_resources.Properties {
         LoadBalancerAttributes exists
-        when LoadBalancerAttributes exists {
-            some LoadBalancerAttributes[*] {
-					Key == "deletion_protection.enabled"
-					Value == true
-			}
+        LoadBalancerAttributes is_list
+        LoadBalancerAttributes not empty
+        
+        some LoadBalancerAttributes[*] {
+            Key == "deletion_protection.enabled"
+            Value == true
+            <<
+                Violation: AWS Application Load Balancers (ALB) must be configured with deletion protection.
+                Fix: Set the 'LoadBalancerAttribute' 'deletion_protection.enabled' to 'true'
+            >>
         }
-        <<
-            Violation: AWS Application Load Balancers (ALB) must be configured with deletion protection.
-            Fix: Set the 'LoadBalancerAttribute' 'deletion_protection.enabled' to 'true'
-        >>
     }
 }

--- a/rules/aws/elastic_load_balancing_v2/elbv2_acm_certificate_required.guard
+++ b/rules/aws/elastic_load_balancing_v2/elbv2_acm_certificate_required.guard
@@ -31,6 +31,7 @@
 # Select all Elastic Load Balancing Resources from incoming template (payload)
 #
 let elbv2_acm_certificate_required_resources = Resources.*[ Type == 'AWS::ElasticLoadBalancingV2::Listener'
+  # Scenario c)
   Properties.Protocol == 'HTTPS' or
   Properties.Protocol == 'TLS'
   Metadata.guard.SuppressedRules not exists or
@@ -38,14 +39,30 @@ let elbv2_acm_certificate_required_resources = Resources.*[ Type == 'AWS::Elasti
 ]
 
 rule ELBV2_ACM_CERTIFICATE_REQUIRED when %elbv2_acm_certificate_required_resources !empty {
+    let doc = this 
     %elbv2_acm_certificate_required_resources.Properties {
-        # Scenarios c) and d)
+        # Scenarios d) and e)
+        Certificates exists
+        Certificates is_list
+        Certificates not empty
+
         Certificates[*] {
-            CertificateArn  exists
-            <<
-                Violation: ELBv2 Listeners need to use HTTPS/SSL certificates provided by AWS Certificate Manager (ACM).
-                Fix: Set the ELBV2 Certificates.*.CertificateArn property to the ARN of an ACM Certificate.
-            >>
+            CertificateArn exists
+            CertificateArn == /arn:aws[a-z0-9\-]*:acm:[a-z0-9\-]+:\d{12}:certificate\/[\w\-]{1,64}/ or 
+            CertificateArn {
+                Ref {
+                    let resource_logical_name = this
+                    let referenced_resource = %doc.Resources[ keys == %resource_logical_name ]
+                    %referenced_resource not empty
+                    %referenced_resource {
+                        Type == "AWS::CertificateManager::Certificate"
+                        <<
+                            Violation: ELBv2 Listeners need to use HTTPS/SSL certificates provided by AWS Certificate Manager (ACM).
+                            Fix: Set the ELBV2 Certificates.*.CertificateArn property to the ARN of an ACM Certificate.
+                        >>
+                    }
+                }
+            }
         }
     }
 }

--- a/rules/aws/elastic_load_balancing_v2/tests/elbv2_acm_certificate_required_tests.yml
+++ b/rules/aws/elastic_load_balancing_v2/tests/elbv2_acm_certificate_required_tests.yml
@@ -54,7 +54,33 @@
     rules:
       ELBV2_ACM_CERTIFICATE_REQUIRED: SKIP
 
-- name: Scenario d) Certificate in 'Certificates' is an ACM certificate for HTTPS or TLS Listeners (HTTPS listener), PASS
+- name: Scenario d) Certificate in 'Certificates' is not an ACM certificate for HTTPS or TLS Listeners (HTTPS listener), FAIL
+  input:
+    Resources:
+      ElbV2Listener:
+        Type: AWS::ElasticLoadBalancingV2::Listener
+        Properties:
+          Protocol: HTTPS
+          Certificates:
+           - CertificateArn: arn:aws:iam::123456789012:server-certificate/example-certificate
+  expectations:
+    rules:
+      ELBV2_ACM_CERTIFICATE_REQUIRED: FAIL
+
+- name: Scenario d) Certificate in 'Certificates' is not an ACM certificate for HTTPS or TLS Listeners (TLS listener), FAIL
+  input:
+    Resources:
+      ElbV2Listener:
+        Type: AWS::ElasticLoadBalancingV2::Listener
+        Properties:
+          Protocol: TLS
+          Certificates:
+           - CertificateArn: arn:aws:iam::123456789012:server-certificate/example-certificate
+  expectations:
+    rules:
+      ELBV2_ACM_CERTIFICATE_REQUIRED: FAIL
+
+- name: Scenario e) Certificate in 'Certificates' is an ACM certificate for HTTPS or TLS Listeners (HTTPS listener), PASS
   input:
     Resources:
       ElbV2Listener:
@@ -67,7 +93,23 @@
     rules:
       ELBV2_ACM_CERTIFICATE_REQUIRED: PASS
 
-- name: Scenario d) Certificate in 'Certificates' is an ACM certificate for HTTPS or TLS Listeners (TLS listener), PASS
+- name: Scenario e) Certificate in 'Certificates' is an ACM certificate for HTTPS or TLS Listeners (HTTPS listener), PASS
+  input:
+    Resources:
+      ACMCertificate:
+        Type: AWS::CertificateManager::Certificate
+      ElbV2Listener:
+        Type: AWS::ElasticLoadBalancingV2::Listener
+        Properties:
+          Protocol: HTTPS
+          Certificates:
+           - CertificateArn:
+              Ref: ACMCertificate
+  expectations:
+    rules:
+      ELBV2_ACM_CERTIFICATE_REQUIRED: PASS
+
+- name: Scenario e) Certificate in 'Certificates' is an ACM certificate for HTTPS or TLS Listeners (TLS listener), PASS
   input:
     Resources:
       ElbV2Listener:
@@ -76,6 +118,22 @@
           Protocol: TLS
           Certificates:
            - CertificateArn: arn:aws:acm:us-west-2:123456789012:certificate/12345678-12ab-34cd-56ef-12345678
+  expectations:
+    rules:
+      ELBV2_ACM_CERTIFICATE_REQUIRED: PASS
+
+- name: Scenario e) Certificate in 'Certificates' is an ACM certificate for HTTPS or TLS Listeners (TLS listener), PASS
+  input:
+    Resources:
+      ACMCertificate:
+        Type: AWS::CertificateManager::Certificate
+      ElbV2Listener:
+        Type: AWS::ElasticLoadBalancingV2::Listener
+        Properties:
+          Protocol: TLS
+          Certificates:
+           - CertificateArn:
+              Ref: ACMCertificate
   expectations:
     rules:
       ELBV2_ACM_CERTIFICATE_REQUIRED: PASS


### PR DESCRIPTION
*Description of changes:* 
* Resolving DSL syntax incompatibilities for use with guard version 2.1.3
* Added additional test cases
* Added regex clauses for ACM certificate rules

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
