### PR TITLE
feat: adding ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK

### DIFF
--- a/rules/aws/amazon_ecs/ecs_task_definition_user_for_host_mode_check.guard
+++ b/rules/aws/amazon_ecs/ecs_task_definition_user_for_host_mode_check.guard
@@ -1,2 +1,69 @@
-    ## Config Rule Name : ecs-task-definition-user-for-host-mode-check
-    ## Config Rule URL: https://docs.aws.amazon.com/config/latest/developerguide/ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK.html"
+#
+#####################################
+##           Gherkin               ##
+#####################################
+#
+# Rule Identifier:
+#   ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK
+#
+# Description:
+#  Checks if an Amazon Elastic Container Service (Amazon ECS) task definition with host networking mode has 'privileged' or 'user' container definitions.
+#
+# Reports on:
+#  AWS::ECS::TaskDefinition
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# Scenarios:
+# a) SKIP: when there are no Autoscaling Group resources present
+# b) SKIP: when metada has rule suppression for ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK
+# c) SKIP: 'ContainerDefinitions' property is not present
+# d) SKIP: 'NetworkMode' property is either not present or set to a value other than 'host'
+# e) FAIL: Entry in 'ContainerDefinitions' has 'User' not present or set to a root user value and 'Privileged' not present or set to 'false' 
+# f) PASS: All entires in 'ContainerDefinitions' have either 'User' set to a non-root user value or 'Privileged' set to 'true'
+
+#
+# Select all ECS Task Definition Resources from incoming template
+#
+let ecs_task_definition_user_for_host_mode_check_resources = Resources.*[ Type == "AWS::ECS::TaskDefinition"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK"
+]
+
+rule ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK when %ecs_task_definition_user_for_host_mode_check_resources !empty {
+    %ecs_task_definition_user_for_host_mode_check_resources[
+        Properties {
+            ContainerDefinitions exists
+            ContainerDefinitions is_list
+            ContainerDefinitions not empty
+
+            NetworkMode exists
+            NetworkMode is_string
+            NetworkMode == "host" 
+        }
+     ] {      
+        Properties.ContainerDefinitions[*] {
+            when User exists
+                 User in [ 0 , "0" , "root" , /^0:.*$/ , /^root:.*$/ ] {
+                    Privileged exists
+                    Privileged == true
+                    <<
+                        Violation: Amazon ECS task definitions using host networking mode must have container definitions that explicitly opt-in to privileged mode, where the container definition user is a root user.
+                        Fix: In 'ContainerDefinitions', where 'User' has been set to a root user value, expliclty opt-in to privileged mode by setting 'Privileged' to 'true'
+                    >>
+            }
+            when User not exists {
+                Privileged exists
+                Privileged == true
+                <<
+                    Violation: Amazon ECS task definitions using host networking mode must have container definitions that explicitly opt-in to privileged mode, where the container definition user is a root user.
+                    Fix: In 'ContainerDefinitions', where 'User' has been set to a root user value, expliclty opt-in to privileged mode by setting 'Privileged' to 'true'
+                >>        
+            }            
+        }       
+    }
+}

--- a/rules/aws/amazon_ecs/tests/ecs_task_definition_user_for_host_mode_check_tests.yml
+++ b/rules/aws/amazon_ecs/tests/ecs_task_definition_user_for_host_mode_check_tests.yml
@@ -1,0 +1,376 @@
+###
+# ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: SKIP
+
+- name: Scenario a) No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: SKIP
+
+- name: Scenario b) Rule suppressed, SKIP
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Metadata:
+          guard:
+            SuppressedRules:
+              - "ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK"
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: SKIP
+
+- name: Scenario c) 'ContainerDefinitions' property is not present, SKIP
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties: {}
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: SKIP
+
+- name: Scenario c) 'ContainerDefinitions' property is not present, SKIP
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          ContainerDefinitions: []
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: SKIP
+
+- name: Scenario d) 'NetworkMode' property is either not present or set to a value other than 'host', SKIP
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: testuser
+          - Name: ContainerB
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: SKIP
+
+- name: Scenario d) 'NetworkMode' property is either not present or set to a value other than 'host', SKIP
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: awsvpc
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: testuser
+          - Name: ContainerB
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: SKIP
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' set to a root user and 'Privileged' not set or set to 'false', FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+            User: root
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' set to a root user and 'Privileged' not set or set to 'false', FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+            User: 0:0
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' set to a root user and 'Privileged' not set or set to 'false', FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged': true
+          - Name: ContainerB
+            User: root
+            Privileged: false
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' set to a root user and 'Privileged' not set or set to 'false', FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+            User: 0:0
+            Privileged: false
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' set to a root user and 'Privileged' not set or set to 'false', FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+            User: root:root
+            Privileged: false
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' set to a root user and 'Privileged' not set or set to 'false', FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+            User: root:root
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' set to a root user and 'Privileged' not set or set to 'false', FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+            User: root:abcd
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' set to a root user and 'Privileged' not set or set to 'false', FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+            User: 0:abcd
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' not present and 'Privileged' not set or set, FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario e) Entry in 'ContainerDefinitions' has 'User' not present and 'Privileged' set to 'false', FAIL
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+            Privileged: false
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: FAIL
+
+- name: Scenario f) All entires in 'ContainerDefinitions' have either 'User' set to a non-root user value or 'Privileged' set to 'true', PASS
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: root
+            Privileged: true
+          - Name: ContainerB
+            User: root
+            Privileged: true
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: PASS
+
+- name: Scenario f) All entires in 'ContainerDefinitions' have either 'User' set to a non-root user value or 'Privileged' set to 'true', PASS
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: testuser
+          - Name: ContainerB
+            Privileged: true
+            User: root
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: PASS
+
+- name: Scenario f) All entires in 'ContainerDefinitions' have either 'User' set to a non-root user value or 'Privileged' set to 'true', PASS
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            Privileged: false
+            User: testuser
+          - Name: ContainerB
+            Privileged: true
+            User: root
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: PASS
+
+- name: Scenario f) All entires in 'ContainerDefinitions' have either 'User' set to a non-root user value or 'Privileged' set to 'true', PASS
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: testuser:root
+            Privileged: false
+          - Name: ContainerB
+            User: root
+            Privileged: true
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: PASS
+
+- name: Scenario f) All entires in 'ContainerDefinitions' have either 'User' set to a non-root user value or 'Privileged' set to 'true', PASS
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: testuser:0
+            Privileged: false
+          - Name: ContainerB
+            User: root
+            Privileged: true
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: PASS
+
+- name: Scenario f) All entires in 'ContainerDefinitions' have either 'User' set to a non-root user value or 'Privileged' set to 'true', PASS
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: 1000:root
+            Privileged: false
+          - Name: ContainerB
+            User: root
+            Privileged: true
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: PASS
+
+- name: Scenario f) All entires in 'ContainerDefinitions' have either 'User' set to a non-root user value or 'Privileged' set to 'true', PASS
+  input:
+    Resources:
+      TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+          NetworkMode: host
+          ContainerDefinitions:
+          - Name: ContainerA
+            User: 1000:0
+            Privileged: false
+          - Name: ContainerB
+            User: root
+            Privileged: true
+  expectations:
+    rules:
+      ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK: PASS


### PR DESCRIPTION
*Issue #, if available:*
closes https://github.com/aws-cloudformation/aws-guard-rules-registry/issues/7

*Description of changes:*
adding ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
