### PR TITLE
feat: adding elb_predefined_security_policy_ssl_check

### DIFF
--- a/rules/aws/elastic_load_balancing/elb_predefined_security_policy_ssl_check.guard
+++ b/rules/aws/elastic_load_balancing/elb_predefined_security_policy_ssl_check.guard
@@ -1,2 +1,67 @@
-## Config Rule Name : elb-predefined-security-policy-ssl-check
-## Config Rule URL: https://docs.aws.amazon.com/config/latest/developerguide/elb-predefined-security-policy-ssl-check.html"
+#
+#####################################
+##           Gherkin               ##
+#####################################
+#
+# Rule Identifier:
+#   ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK
+#
+# Description:
+#   This rule checks whether Classic Load Balancers HTTPS/SSL listeners use the predefined security policy 'ELBSecurityPolicy-TLS-1-2-2017-01'.
+#
+# Reports on:
+#   AWS::ElasticLoadBalancing::LoadBalancer
+#
+# Evaluates:
+#   AWS CloudFormation
+#
+# Rule Parameters:
+#   None
+#
+# Scenarios:
+# a) SKIP: when there are no Elastic Load Balancing Resources
+# b) SKIP: when metadata has rule suppression for ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK
+# c) SKIP: when there are no HTTPS or SSL 'Listeners' configured
+# d) FAIL: when 'Policies' does not contain a policy with 'PolicyType' equal to 'SSLNegotiationPolicyType' and 'Reference-Security-Policy' with a value of
+#          'ELBSecurityPolicy-TLS-1-2-2017-01'
+# e) FAIL: when a 'HTTPS' or 'SSL' Listener on the load balancer resource does not reference a secure policy
+# f) PASS: when all 'HTTPS' and 'SSL' Listeners on the load balancer resource reference a secure policy
+
+#
+# Select all Elastic Load Balancing Resources from incoming template (payload)
+#
+let elb_predefined_security_policy_ssl_check = Resources.*[ Type == 'AWS::ElasticLoadBalancing::LoadBalancer'
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK"
+]
+
+rule ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK when %elb_predefined_security_policy_ssl_check !empty {
+    %elb_predefined_security_policy_ssl_check.Properties {
+        let elb = this
+
+        Listeners[ Protocol in ["HTTPS", "SSL"] ] {
+            %elb.Policies exists
+            %elb.Policies is_list
+            %elb.Policies not empty
+
+            let secure_policies = %elb.Policies[
+                PolicyType == "SSLNegotiationPolicyType"
+                some Attributes[*] {
+                    Name == "Reference-Security-Policy"
+                    Value in [ "ELBSecurityPolicy-TLS-1-2-2017-01" ]
+                }
+            ].PolicyName
+
+            %secure_policies not empty
+
+            PolicyNames exists
+            PolicyNames is_list
+            PolicyNames not empty
+            some PolicyNames.* in %secure_policies
+                <<
+                    Violation: Classic Load Balancers HTTPS/SSL listeners use the predefined security policy 'ELBSecurityPolicy-TLS-1-2-2017-01'
+                    Fix: Configure Classic Load Balancer HTTPS/SSL listeners to use the predefined security policy 'ELBSecurityPolicy-TLS-1-2-2017-01'
+                >>
+        }
+    }
+}

--- a/rules/aws/elastic_load_balancing/tests/elb_predefined_security_policy_ssl_check_tests.yml
+++ b/rules/aws/elastic_load_balancing/tests/elb_predefined_security_policy_ssl_check_tests.yml
@@ -1,0 +1,329 @@
+###
+# ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: SKIP
+
+- name: Scenario a) No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: SKIP
+
+- name: Scenario b) Rule suppressed, SKIP
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Metadata:
+          guard:
+            SuppressedRules:
+              - "ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK"
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: SKIP
+
+- name: Scenario c) No HTTPS or SSL 'Listeners' configured, SKIP
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners: []
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: SKIP
+
+- name: Scenario c) No HTTPS or SSL 'Listeners' configured, SKIP
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+          - Protocol: HTTP
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: SKIP
+
+- name: Scenario c) No HTTPS or SSL 'Listeners' configured, SKIP
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+          - Protocol: HTTP
+          - Protocol: TCP
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: SKIP
+
+- name: Scenario d) 'Policies' does not contain a policy with 'PolicyType' equal to 'SSLNegotiationPolicyType' and 'Reference-Security-Policy' with a value of 'ELBSecurityPolicy-TLS-1-2-2017-01', FAIL
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+          - Protocol: HTTPS
+          Policies: []
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: FAIL
+
+- name: Scenario d) 'Policies' does not contain a policy with 'PolicyType' equal to 'SSLNegotiationPolicyType' and 'Reference-Security-Policy' with a value of 'ELBSecurityPolicy-TLS-1-2-2017-01', FAIL
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+          - Protocol: HTTPS
+          Policies:
+          - PolicyName: My-Cookie-Policy
+            PolicyType: LBCookieStickinessPolicyType
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: FAIL
+
+- name: Scenario d) 'Policies' does not contain a policy with 'PolicyType' equal to 'SSLNegotiationPolicyType' and 'Reference-Security-Policy' with a value of 'ELBSecurityPolicy-TLS-1-2-2017-01', FAIL
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+          - Protocol: HTTPS
+          Policies:
+          - PolicyName: My-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-2016-08        
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: FAIL
+
+- name: Scenario d) 'Policies' does not contain a policy with 'PolicyType' equal to 'SSLNegotiationPolicyType' and 'Reference-Security-Policy' with a value of 'ELBSecurityPolicy-TLS-1-2-2017-01', FAIL
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Listeners:
+          - Protocol: HTTPS
+          Policies:
+          - PolicyName: My-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Protocol-TLSv1
+              Value: true      
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: FAIL
+
+- name: Scenario e) 'HTTPS' or 'SSL' Listener on the load balancer resource does not reference a secure policy, FAIL
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Policies:
+          - PolicyName: Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: FAIL
+
+- name: Scenario e) 'HTTPS' or 'SSL' Listener on the load balancer resource does not reference a secure policy, FAIL
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Policies:
+          - PolicyName: Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
+          - PolicyName: Non-Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-2016-08
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+            PolicyNames: []
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: FAIL
+
+- name: Scenario e) 'HTTPS' or 'SSL' Listener on the load balancer resource does not reference a secure policy, FAIL
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Policies:
+          - PolicyName: Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
+          - PolicyName: Non-Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-2016-08
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+            PolicyNames:
+            - Non-Compliant-SSLNegotiation-Policy
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: FAIL
+
+- name: Scenario e) 'HTTPS' or 'SSL' Listener on the load balancer resource does not reference a secure policy, FAIL
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Policies:
+          - PolicyName: Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
+          - PolicyName: Non-Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-2016-08
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+            PolicyNames:
+            - Non-Compliant-SSLNegotiation-Policy
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '8443'
+            Protocol: HTTPS
+            PolicyNames:
+            - Compliant-SSLNegotiation-Policy
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: FAIL
+
+- name: Scenario f) all 'HTTPS' and 'SSL' Listeners on the load balancer resource reference a secure policy, PASS
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Policies:
+          - PolicyName: Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
+          - PolicyName: Non-Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-2016-08
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+            PolicyNames:
+            - Compliant-SSLNegotiation-Policy
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: PASS
+
+- name: Scenario f) all 'HTTPS' and 'SSL' Listeners on the load balancer resource reference a secure policy, PASS
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Policies:
+          - PolicyName: Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
+          - PolicyName: Non-Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-2016-08
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: SSL
+            PolicyNames:
+            - Compliant-SSLNegotiation-Policy
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: PASS
+
+- name: Scenario f) all 'HTTPS' and 'SSL' Listeners on the load balancer resource reference a secure policy, PASS
+  input:
+    Resources:
+      Elb:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          Policies:
+          - PolicyName: Compliant-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
+          - PolicyName: Compliant-Second-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: SSL
+            PolicyNames:
+            - Compliant-SSLNegotiation-Policy
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '8443'
+            Protocol: SSL
+            PolicyNames:
+            - Compliant-Second-SSLNegotiation-Policy
+  expectations:
+    rules:
+      ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK: PASS


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/aws-guard-rules-registry/issues/98

*Description of changes:*
Adding `ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK`

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
