### PR TITLE
fix: Changed syntax for intrinsic functions

### DIFF
--- a/rules/aws/lambda/lambda_function_public_access_prohibited.guard
+++ b/rules/aws/lambda/lambda_function_public_access_prohibited.guard
@@ -40,7 +40,7 @@ rule LAMBDA_FUNCTION_PUBLIC_ACCESS_PROHIBITED when %aws_lambda_permissions_publi
   %aws_lambda_permissions_public_access_prohibited {
     Type == 'AWS::Lambda::Permission'
     Properties {
-      Principal in [ /^\d{12}$/, "AWS::AccountId" ]
+      Principal in [ /^\d{12}$/, {"Ref":"AWS::AccountId"} ]
       OR Principal > 0
     }
   }
@@ -82,7 +82,7 @@ rule LAMBDA_FUNCTION_PUBLIC_ACCESS_PROHIBITED when %aws_lambda_permissions_publi
     Type == 'AWS::Lambda::LayerVersionPermission'
     Properties {
       OrganizationId !empty
-      OR Principal in [ /^\d{12}$/, "AWS::AccountId" ]
+      OR Principal in [ /^\d{12}$/, {"Ref":"AWS::AccountId"} ]
       OR Principal > 0
       <<
         Violation: All Lambda permission policies attached to Lambda resources must prohibit public access.


### PR DESCRIPTION
*Issue #, if available:*
Changes as per [PR#331](https://github.com/aws-cloudformation/cloudformation-guard/pull/331) for `cfn-guard`

*Description of changes:*
As per the expected behavior intrinsic functions in template like `!Ref AWS::AccountId` are supposed to get evaluated to the expanded JSON syntax i.e, `{"Ref":"AWS::AccountId"}` as opposed to `"AWS::AccountId"`.


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
