### PR TITLE
fix: spelling error in ec2_ebs_encryption_by_default rule

### DIFF
--- a/rules/aws/amazon_ec2/ec2_ebs_encryption_by_default.guard
+++ b/rules/aws/amazon_ec2/ec2_ebs_encryption_by_default.guard
@@ -33,7 +33,7 @@ let ec2_ebs_volumes_encrypted_by_default = Resources.*[ Type == 'AWS::EC2::Volum
 rule EC2_EBS_ENCRYPTION_BY_DEFAULT when %ec2_ebs_volumes_encrypted_by_default !empty {
     %ec2_ebs_volumes_encrypted_by_default.Properties.Encrypted == true 
 		<<
-			Violation: All EBS Volumes should be encryped 
+			Violation: All EBS Volumes should be encrypted 
 			Fix: Set Encrypted property to true
 		>>
 }


### PR DESCRIPTION
Error in encrypted spelling in guard rule for ebs


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
