### PR TITLE
feat: Migrate Sagemaker SNS and SQS resources to cfn-guard ruleset

### DIFF
--- a/rules/aws/amazon_sagemaker/sagemaker_endpoint_configuration_kms_key_configured.guard
+++ b/rules/aws/amazon_sagemaker/sagemaker_endpoint_configuration_kms_key_configured.guard
@@ -28,6 +28,8 @@
 # Select all AWS::SageMaker::EndpointConfig resources from incoming template (payload)
 #
 let sagemaker_endpoint_configuration_kms_key_configured = Resources.*[ Type == "AWS::SageMaker::EndpointConfig"
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W1200"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "SAGEMAKER_ENDPOINT_CONFIGURATION_KMS_KEY_CONFIGURED"
 ]

--- a/rules/aws/amazon_sagemaker/sagemaker_notebook_instance_kms_key_configured.guard
+++ b/rules/aws/amazon_sagemaker/sagemaker_notebook_instance_kms_key_configured.guard
@@ -29,6 +29,8 @@
 #
 
 let sagemaker_notebook_instance_kms_key_configured = Resources.*[ Type == "AWS::SageMaker::NotebookInstance"
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W1201"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "SAGEMAKER_NOTEBOOK_INSTANCE_KMS_KEY_CONFIGURED"
 ]

--- a/rules/aws/amazon_sagemaker/tests/sagemaker_endpoint_configuration_kms_key_configured_tests.yml
+++ b/rules/aws/amazon_sagemaker/tests/sagemaker_endpoint_configuration_kms_key_configured_tests.yml
@@ -40,6 +40,32 @@
     rules:
       SAGEMAKER_ENDPOINT_CONFIGURATION_KMS_KEY_CONFIGURED: SKIP
 
+- name: Scenario b) Missing KmsKeyId but rule suppressed - CFN_NAG, SKIP
+  input:
+    Resources:
+      Endpoint:
+        Type: "AWS::SageMaker::Endpoint"
+        Properties:
+          EndpointConfigName:
+            !GetAtt EndpointConfig.EndpointConfigName
+      EndpointConfig:
+        Type: "AWS::SageMaker::EndpointConfig"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W1200
+              reason: Suppressed for a very good reason
+        Properties:
+          ProductionVariants:
+          - InitialInstanceCount: 1
+            InitialVariantWeight: 1.0
+            InstanceType: ml.t2.large
+            ModelName: !GetAtt Model.ModelName
+            VariantName: !GetAtt Model.ModelName
+  expectations:
+    rules:
+      SAGEMAKER_ENDPOINT_CONFIGURATION_KMS_KEY_CONFIGURED: SKIP
+
 - name: Scenario c) Missing KmsKeyId, FAIL
   input: 
     Resources:

--- a/rules/aws/amazon_sagemaker/tests/sagemaker_notebook_instance_kms_key_configured_tests.yml
+++ b/rules/aws/amazon_sagemaker/tests/sagemaker_notebook_instance_kms_key_configured_tests.yml
@@ -32,6 +32,24 @@
     rules:
       SAGEMAKER_NOTEBOOK_INSTANCE_KMS_KEY_CONFIGURED: SKIP
 
+- name: Scenario b) KmsKeyId not present but rule suppressed - CFN_NAG, SKIP
+  input:
+    Resources:
+      BasicNotebookInstance:
+        Type: "AWS::SageMaker::NotebookInstance"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W1201
+              reason: Suppressed for a very good reason
+        Properties:
+          InstanceType: "ml.t2.large"
+          RoleArn: !GetAtt ExecutionRole.Arn
+          RootAccess: Enabled
+  expectations:
+    rules:
+      SAGEMAKER_NOTEBOOK_INSTANCE_KMS_KEY_CONFIGURED: SKIP
+
 - name: Scenario c) KmsKeyId not present, FAIL
   input:
     Resources:

--- a/rules/aws/amazon_sns/sns_encrypted_kms.guard
+++ b/rules/aws/amazon_sns/sns_encrypted_kms.guard
@@ -29,6 +29,8 @@
 #
 
 let sns_encrypted_kms = Resources.*[ Type == "AWS::SNS::Topic"
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W47"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "SNS_ENCRYPTED_KMS"
 ]

--- a/rules/aws/amazon_sns/sns_topicpolicy_no_allow_plus_not_action.guard
+++ b/rules/aws/amazon_sns/sns_topicpolicy_no_allow_plus_not_action.guard
@@ -1,0 +1,52 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#   SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION
+#
+# Description:
+#   Checks that SIMPLE NOTIFICATION SERVICE (SNS) TOPIC Policy do not use Allow+NotAction
+#
+# Reports on:
+#   AWS::SNS::TopicPolicy
+#
+# Evaluates:
+#   AWS CloudFormation
+#
+# Rule Parameters:
+#   NA
+#
+# CFN_NAG Rule Id:
+#   W19
+#
+# Documentation:
+# https://docs.aws.amazon.com/sns/latest/dg/sns-using-identity-based-policies.html
+#
+# Scenarios:
+# a) SKIP: when there are no SNS Topic Policies present
+# b) PASS: when all SNS Topic Policies do not use Allow+NotAction
+# c) FAIL: when any SNS Topic Policies allow both Effect: Allow and NotAction
+# d) SKIP: when metadata has rule suppression for SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION or CFN_NAG W19
+
+let sns_topicpolicy_no_allow_plus_not_action = Resources.*[ Type == 'AWS::SNS::TopicPolicy'
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W19"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION"
+]
+
+rule SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION when %sns_topicpolicy_no_allow_plus_not_action !empty {
+  let violations = %sns_topicpolicy_no_allow_plus_not_action[
+    Type == 'AWS::SNS::TopicPolicy'
+    some Properties.PolicyDocument.Statement[*] {
+      Effect == "Allow"
+      NotAction exists
+    }
+  ]
+  %violations empty
+  <<
+    Violation: SNS TopicPolicy should not allow Allow+NotAction
+    Fix: Remove SNS Topic Policies that match {"Effect": "Allow", "NotAction": ... }
+  >>
+}

--- a/rules/aws/amazon_sns/sns_topicpolicy_no_allow_plus_notprincipal.guard
+++ b/rules/aws/amazon_sns/sns_topicpolicy_no_allow_plus_notprincipal.guard
@@ -1,0 +1,54 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#   SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL
+#
+# Description:
+#   Checks that Amazon SNS TopicPolicies do not use Effect:Allow with NotPrincipal
+#
+# Reports on:
+#   AWS::SNS::TopicPolicy
+#
+# Evaluates:
+#   AWS CloudFormation
+#
+# Rule Parameters:
+#   NA
+# 
+# CFN_NAG Rule Id:
+#   F8
+#
+# Documentation:
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html
+#
+# Scenarios:
+# a) SKIP: when there are no SNS TopicPolicies present
+# b) PASS: when all SNS TopicPolicies do not Allow with NotPrincipal
+# c) FAIL: when any SNS TopicPolicy PolicyDocument statement has both Effect: Allow and NotPrincipal
+# d) SKIP: when metada has rule suppression for SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL or CFN_NAG F8
+
+#
+# Select all SNS TopicPolicy resources from incoming template (payload)
+# 
+let aws_sqs_queuepolicy_resources = Resources.*[ Type == 'AWS::SNS::TopicPolicy'
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F8"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL" 
+]
+
+rule SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL when %aws_sqs_queuepolicy_resources !empty {
+  let violations = %aws_sqs_queuepolicy_resources[
+    some Properties.PolicyDocument.Statement[*] {
+      Effect == "Allow"
+      NotPrincipal exists
+    }
+  ]
+  %violations empty
+  <<
+    Violation: SNS TopciPolicy should not allow Allow+NotPrincipal
+    Fix: Remove policy statements that match {"Effect": "Allow", "NotPrincipal": ... }
+  >>
+} 

--- a/rules/aws/amazon_sns/sns_topicpolicy_no_wildcard_principal.guard
+++ b/rules/aws/amazon_sns/sns_topicpolicy_no_wildcard_principal.guard
@@ -1,0 +1,54 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#    SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL
+#
+# Description:
+#   SNS Topic policy should not allow * principal
+#
+# Reports on:
+#    AWS::SNS::TopicPolicy
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# CFN_NAG Rule Id:
+#   F18
+#
+# Reference:
+#   https://docs.aws.amazon.com/sns/latest/dg/sns-access-policy-use-cases.html
+#
+# Scenarios:
+# a) SKIP: when there is no SNS TopicPolicy resource present
+# b) PASS: when no SNS TopicPolicy resources have open Principal
+# c) FAIL: when any SNS TopicPolicy has Principal "*"
+# d) SKIP: when metada has rule suppression for SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL
+
+#
+# Select all SNS TopicPolicy resources from incoming template (payload)
+#
+let sns_topicpolicy_no_wildcard_principal = Resources.*[ Type == 'AWS::SNS::TopicPolicy'
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F18"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL"
+]
+
+rule SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL when %sns_topicpolicy_no_wildcard_principal !empty {
+  let violations = %sns_topicpolicy_no_wildcard_principal[
+    some Properties.PolicyDocument.Statement[*] {
+      Principal == "*" OR Principal.AWS == "*" OR Principal == "arn:aws:iam::*"
+      Effect == "Allow"
+    }
+  ]
+  %violations empty
+  <<
+    Violation: SNS Topic policy should not allow * principal
+    Fix: Specify explicit principals in the SNS TopicPolicy
+  >>
+}

--- a/rules/aws/amazon_sns/tests/sns_encrypted_kms_tests.yml
+++ b/rules/aws/amazon_sns/tests/sns_encrypted_kms_tests.yml
@@ -62,6 +62,54 @@
     rules:
       SNS_ENCRYPTED_KMS: SKIP
 
+- name: Scenario b) KmsMasterKeyId not set but rule suppressed, SKIP
+  input:
+    Resources:
+      MySNSTopic:
+        Type: AWS::SNS::Topic
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W47
+              reason: Suppressed for a very good reason
+        Properties:
+          Subscription:
+            - Endpoint:
+                Fn::GetAtt:
+                  - "MyQueue1"
+                  - "Arn"
+              Protocol: "sqs"
+            - Endpoint:
+                Fn::GetAtt:
+                  - "MyQueue2"
+                  - "Arn"
+              Protocol: "sqs"
+          TopicName: "SampleTopic"
+      MySNSTopicPolicy:
+        Type: AWS::SNS::TopicPolicy
+        Properties:
+          Topics:
+            - Ref: MySNSTopic
+          PolicyDocument:
+            Version: "2008-10-17"
+            Id: Policy1415489375392
+            Statement:
+              - Sid: deny-unless-tls
+                Effect: Deny
+                Principal:
+                  AWS: "*"
+                Action:
+                  - sns:Publish
+                Resource: arn:aws:sns:us-east-2:111122223333:MySNSTopic
+                Condition:
+                  Bool:
+                    aws:SecureTransport: false
+                  NumericLessThan:
+                    s3:TlsVersion: 1.2
+  expectations:
+    rules:
+      SNS_ENCRYPTED_KMS: SKIP
+
 - name: Scenario c) KmsMasterKeyId not set, FAIL
   input:
     Resources:

--- a/rules/aws/amazon_sns/tests/sns_topicpolicy_no_allow_plus_not_action_tests.yml
+++ b/rules/aws/amazon_sns/tests/sns_topicpolicy_no_allow_plus_not_action_tests.yml
@@ -1,0 +1,134 @@
+###
+# SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION tests
+###
+---
+- name: Empty
+  input: {}
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP
+
+- name: No resources
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Deny and NotAction
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Deny
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION: PASS
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Allow and NotAction
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+           - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION: FAIL
+
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Allow and NotAction, but rule suppressed
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          guard:
+            SuppressedRules:
+            - SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Allow and NotAction, but rule suppressed - CFN_NAG
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W19
+              reason: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Allow and NotAction, but rule suppressed - BOTH
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W19
+              reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+            - SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP

--- a/rules/aws/amazon_sns/tests/sns_topicpolicy_no_allow_plus_notprincipal_tests.yml
+++ b/rules/aws/amazon_sns/tests/sns_topicpolicy_no_allow_plus_notprincipal_tests.yml
@@ -1,0 +1,134 @@
+###
+# SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP
+
+- name: No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Deny, PASS
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Deny
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: PASS
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Allow, FAIL
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+           - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: FAIL
+
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Allow, but rule suppressed, SKIP
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          guard:
+            SuppressedRules:
+            - SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Allow, but rule suppressed - CFN_NAG, SKIP
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F8
+              reason: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP
+
+- name: SNS TopicPolicy PolicyDocument with Effect:Allow, but rule suppressed - BOTH, SKIP
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F8
+              reason: Suppressed for a very good reason
+          guard:
+            SuppressedRules:
+            - SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP

--- a/rules/aws/amazon_sns/tests/sns_topicpolicy_no_wildcard_principal_tests.yml
+++ b/rules/aws/amazon_sns/tests/sns_topicpolicy_no_wildcard_principal_tests.yml
@@ -1,0 +1,157 @@
+###
+# SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: SKIP
+
+- name: No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: SKIP
+
+- name: SNS TopicPolicy with Principal *, Effect:Deny, PASS
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Deny
+              Principal: "*"
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: PASS
+
+- name: SNS TopicPolicy with specific Principals, PASS
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+           - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Principal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: PASS
+
+- name: SNS TopicPolicy with Principal *, Effect Allow, FAIL
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+            - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Principal: 
+                AWS: "*"
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: FAIL
+
+- name: SNS TopicPolicy with Principal iam *, Effect Allow, FAIL
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+            - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Principal: "arn:aws:iam::*"
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: FAIL
+
+- name: F18 CFN_NAG suppression, SKIP
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+            - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Principal: 
+                AWS: "*"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F18
+              reason: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: SKIP
+
+- name: SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL Guard suppression, SKIP
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Principal: "*"
+        Metadata:
+          guard:
+            SuppressedRules:
+            - SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: SKIP
+
+- name: F18 CFN_NAG & SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL Guard suppression, SKIP
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SNS::TopicPolicy"
+        Properties:
+          Topics:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Principal: "arn:aws:iam::*"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F18
+              reason: Suppressed for a very good reason
+          guard:
+            SuppressedRules:
+            - SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SNS_TOPICPOLICY_NO_WILDCARD_PRINCIPAL: SKIP

--- a/rules/aws/amazon_sqs/sqs_queue_kms_master_key_id_rule.guard
+++ b/rules/aws/amazon_sqs/sqs_queue_kms_master_key_id_rule.guard
@@ -1,0 +1,46 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#    SQS_QUEUE_KMS_MASTER_KEY_ID_RULE
+#
+# Description:
+#   SQS Queue should specify KmsMasterKeyId property
+#
+# Reports on:
+#    AWS::SQS::Queue
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# CFN_NAG Rule Id:
+#   W48
+#
+# Scenarios:
+# a) SKIP: when there is no SQS Queue resource present.
+# b) PASS: when SQS Queue resources have KmsMasterKeyId Key.
+# c) FAIL: when SQS Queue resources does not have KmsMasterKeyId Key.
+# d) SKIP: when metadata has rule suppression for SQS_QUEUE_KMS_MASTER_KEY_ID_RULE
+
+#
+# Select all SQS Queue resources from incoming template (payload)
+#
+let sqs_queue_kms_master_key_id_rule = Resources.*[ Type == 'AWS::SQS::Queue'
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W48"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "SQS_QUEUE_KMS_MASTER_KEY_ID_RULE"
+]
+
+rule SQS_QUEUE_KMS_MASTER_KEY_ID_RULE when %sqs_queue_kms_master_key_id_rule !empty {
+  %sqs_queue_kms_master_key_id_rule.Type == 'AWS::SQS::Queue'
+  %sqs_queue_kms_master_key_id_rule.Properties.KmsMasterKeyId exists
+  <<
+    Violation: SQS Queue KmsMasterKeyId does not exist
+    Fix: Specify KmsMasterKeyId value
+  >>
+}

--- a/rules/aws/amazon_sqs/sqs_queuepolicy_no_allow_plus_not_action.guard
+++ b/rules/aws/amazon_sqs/sqs_queuepolicy_no_allow_plus_not_action.guard
@@ -1,0 +1,52 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#   SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION
+#
+# Description:
+#   Checks that SIMPLE QUEUE SERVICE (SQS) Queue Policy do not use Allow+NotAction
+#
+# Reports on:
+#   AWS::SQS::QueuePolicy
+#
+# Evaluates:
+#   AWS CloudFormation
+#
+# Rule Parameters:
+#   NA
+#
+# CFN_NAG Rule Id:
+#   W18
+#
+# Documentation:
+# https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-overview-of-managing-access.html
+#
+# Scenarios:
+# a) SKIP: when there are no SQS Queue Policies present
+# b) PASS: when all SQS Queue Policies do not use Allow+NotAction
+# c) FAIL: when any SQS Queue Policies allow both Effect: Allow and NotAction
+# d) SKIP: when metadata has rule suppression for SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION or CFN_NAG W18
+
+let sqs_queuepolicy_no_allow_plus_not_action = Resources.*[ Type == 'AWS::SQS::QueuePolicy'
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W18"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION"
+]
+
+rule SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION when %sqs_queuepolicy_no_allow_plus_not_action !empty {
+  let violations = %sqs_queuepolicy_no_allow_plus_not_action[
+    Type == 'AWS::SQS::QueuePolicy'
+    some Properties.PolicyDocument.Statement[*] {
+      Effect == "Allow"
+      NotAction exists
+    }
+  ]
+  %violations empty
+  <<
+    Violation: SQS QueuePolicy should not allow Allow+NotAction
+    Fix: Remove SQS Queue Policies that match {"Effect": "Allow", "NotAction": ... }
+  >>
+}

--- a/rules/aws/amazon_sqs/sqs_queuepolicy_no_allow_plus_notprincipal.guard
+++ b/rules/aws/amazon_sqs/sqs_queuepolicy_no_allow_plus_notprincipal.guard
@@ -1,0 +1,55 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#   SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL
+#
+# Description:
+#   Checks that Amazon SQS Queue Policies do not use Effect:Allow with NotPrincipal
+#
+# Reports on:
+#   AWS::SQS::QueuePolicy
+#
+# Evaluates:
+#   AWS CloudFormation
+#
+# Rule Parameters:
+#   NA
+# 
+# CFN_NAG Rule Id:
+#   F7
+#
+# Documentation:
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html
+#
+# Scenarios:
+# a) SKIP: when there are no SQS QueuePolicies present
+# b) PASS: when all SQS QueuePolicies do not Allow with NotPrincipal
+# c) FAIL: when any SQS QueuePolicy PolicyDocument statement has both Effect: Allow and NotPrincipal
+# d) SKIP: when metada has rule suppression for SQS_NO_QUEUE_POLICY_NOT_PRINCIPAL or CFN_NAG F7
+
+#
+# Select all SQS QueuePolicy resources from incoming template (payload)
+# 
+let aws_sqs_queuepolicy_resources = Resources.*[ Type == 'AWS::SQS::QueuePolicy'
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F7"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL" 
+]
+
+rule SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL when %aws_sqs_queuepolicy_resources !empty {
+  let violations = %aws_sqs_queuepolicy_resources[
+    Type == 'AWS::SQS::QueuePolicy' 
+    some Properties.PolicyDocument.Statement[*] {
+      Effect == "Allow"
+      NotPrincipal exists
+    }
+  ]
+  %violations empty
+  <<
+    Violation: SQS QueuePolicy should not allow Allow+NotPrincipal
+    Fix: Remove policy statements that match {"Effect": "Allow", "NotPrincipal": ... }
+  >>
+} 

--- a/rules/aws/amazon_sqs/sqs_queuepolicy_no_wildcard_action.guard
+++ b/rules/aws/amazon_sqs/sqs_queuepolicy_no_wildcard_action.guard
@@ -1,0 +1,54 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#    SQS_QUEUEPOLICY_NO_WILDCARD_ACTION
+#
+# Description:
+#   SQS Queue policy should not allow * action
+#
+# Reports on:
+#    AWS::SQS::QueuePolicy
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# CFN_NAG Rule Id:
+#   F20
+#
+# Reference:
+#   https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-overview-of-managing-access.html
+#
+# Scenarios:
+# a) SKIP: when there is no SQS QueuePolicy resource present
+# b) PASS: when no SQS QueuePolicy resources have open Actions
+# c) FAIL: when any SQS QueuePolicy has Action "*" or contains <service:*>
+# d) SKIP: when metada has rule suppression for SQS_QUEUEPOLICY_NO_WILDCARD_ACTION
+
+#
+# Select all SQS QueuePolicy resources from incoming template (payload)
+#
+let sqs_queuepolicy_no_wildcard_action = Resources.*[ Type == 'AWS::SQS::QueuePolicy'
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F20"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "SQS_QUEUEPOLICY_NO_WILDCARD_ACTION"
+]
+
+rule SQS_QUEUEPOLICY_NO_WILDCARD_ACTION when %sqs_queuepolicy_no_wildcard_action !empty {
+  let violations = %sqs_queuepolicy_no_wildcard_action[
+    some Properties.PolicyDocument.Statement[*] {
+      some Action[*] in ["*", /^[a-zA-Z0-9]*:\*$/]
+      Effect == "Allow"
+    }
+  ]
+  %violations empty
+  <<
+    Violation: SQS Queue policy should not allow * Action
+    Fix: Specify explicit Action(s) in the SQS QueuePolicy
+  >>
+}

--- a/rules/aws/amazon_sqs/sqs_queuepolicy_no_wildcard_principal.guard
+++ b/rules/aws/amazon_sqs/sqs_queuepolicy_no_wildcard_principal.guard
@@ -1,0 +1,54 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#    SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL
+#
+# Description:
+#   SQS Queue policy should not allow * principal
+#
+# Reports on:
+#    AWS::SQS::QueuePolicy
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# CFN_NAG Rule Id:
+#   F21
+#
+# Reference:
+#   https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-overview-of-managing-access.html
+#
+# Scenarios:
+# a) SKIP: when there is no SQS QueuePolicy resource present
+# b) PASS: when no SQS QueuePolicy resources have open Principal
+# c) FAIL: when any SQS QueuePolicy has Principal "*"
+# d) SKIP: when metada has rule suppression for SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL
+
+#
+# Select all SQS QueuePolicy resources from incoming template (payload)
+#
+let sqs_queuepolicy_no_wildcard_principal = Resources.*[ Type == 'AWS::SQS::QueuePolicy'
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F21"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL"
+]
+
+rule SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL when %sqs_queuepolicy_no_wildcard_principal !empty {
+  let violations = %sqs_queuepolicy_no_wildcard_principal[
+    some Properties.PolicyDocument.Statement[*] {
+      Principal == "*" OR Principal.AWS == "*" OR Principal == "arn:aws:iam::*"
+      Effect == "Allow"
+    }
+  ]
+  %violations empty
+  <<
+    Violation: SQS QueuePolicy should not allow * principal
+    Fix: Specify explicit principals in the SQS QueuePolicy
+  >>
+}

--- a/rules/aws/amazon_sqs/tests/sqs_queue_kms_master_key_id_rule_tests.yml
+++ b/rules/aws/amazon_sqs/tests/sqs_queue_kms_master_key_id_rule_tests.yml
@@ -1,0 +1,114 @@
+###
+# SQS_QUEUE_KMS_MASTER_KEY_ID_RULE tests
+###
+---
+- name: Empty
+  input: {}
+  expectations:
+    rules:
+      SQS_QUEUE_KMS_MASTER_KEY_ID_RULE: SKIP
+
+- name: No resources
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      SQS_QUEUE_KMS_MASTER_KEY_ID_RULE: SKIP
+
+- name: SQS Queue with KmsMasterKeyId
+  input:
+    Resources:
+      MySourceQueue:
+        Type: AWS::SQS::Queue
+        Properties:
+          RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - "MyDeadLetterQueue"
+                - "Arn"
+            maxReceiveCount: 5
+          KmsMasterKeyId: 'TestKey'
+  expectations:
+    rules:
+      SQS_QUEUE_KMS_MASTER_KEY_ID_RULE: PASS
+
+- name: SQS Queue without KmsMasterKeyId
+  input:
+    Resources:
+      MySourceQueue:
+        Type: AWS::SQS::Queue
+        Properties:
+          RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - "MyDeadLetterQueue"
+                - "Arn"
+            maxReceiveCount: 5
+  expectations:
+    rules:
+      SQS_QUEUE_KMS_MASTER_KEY_ID_RULE: FAIL
+
+- name: CFN_NAG suppression for W48
+  input:
+    Resources:
+      MySourceQueue:
+        Type: AWS::SQS::Queue
+        Properties:
+          RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - "MyDeadLetterQueue"
+                - "Arn"
+            maxReceiveCount: 5
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W48
+              reason: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      SQS_QUEUE_KMS_MASTER_KEY_ID_RULE: SKIP
+
+- name: Guard suppression for SQS_QUEUE_KMS_MASTER_KEY_ID_RULE
+  input:
+    Resources:
+      MySourceQueue:
+        Type: AWS::SQS::Queue
+        Properties:
+          RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - "MyDeadLetterQueue"
+                - "Arn"
+            maxReceiveCount: 5
+        Metadata:
+          guard:
+            SuppressedRules:
+            - SQS_QUEUE_KMS_MASTER_KEY_ID_RULE
+  expectations:
+    rules:
+      SQS_QUEUE_KMS_MASTER_KEY_ID_RULE: SKIP
+
+- name: Guard and CFN_NAG suppression for W48 & SQS_QUEUE_KMS_MASTER_KEY_ID_RULE
+  input:
+    Resources:
+      MySourceQueue:
+        Type: AWS::SQS::Queue
+        Properties:
+          RedrivePolicy:
+            deadLetterTargetArn:
+              Fn::GetAtt:
+                - "MyDeadLetterQueue"
+                - "Arn"
+            maxReceiveCount: 5
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W48
+              reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+            - SQS_QUEUE_KMS_MASTER_KEY_ID_RULE
+  expectations:
+    rules:
+      SQS_QUEUE_KMS_MASTER_KEY_ID_RULE: SKIP

--- a/rules/aws/amazon_sqs/tests/sqs_queuepolicy_no_allow_plus_not_action_tests.yml
+++ b/rules/aws/amazon_sqs/tests/sqs_queuepolicy_no_allow_plus_not_action_tests.yml
@@ -1,0 +1,134 @@
+###
+# SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION tests
+###
+---
+- name: Empty
+  input: {}
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP
+
+- name: No resources
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Deny and NotAction
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Deny
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION: PASS
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Allow and NotAction
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION: FAIL
+
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Allow, but rule suppressed
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          guard:
+            SuppressedRules:
+            - SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Allow, but rule suppressed - CFN_NAG
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W18
+              reason: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Allow, but rule suppressed - BOTH
+  input:
+    Resources:
+      ExampleResource:
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotAction:
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W18
+              reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+            - SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOT_ACTION: SKIP

--- a/rules/aws/amazon_sqs/tests/sqs_queuepolicy_no_allow_plus_notprincipal_tests.yml
+++ b/rules/aws/amazon_sqs/tests/sqs_queuepolicy_no_allow_plus_notprincipal_tests.yml
@@ -1,0 +1,134 @@
+###
+# SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP
+
+- name: No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Deny, PASS
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Deny
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: PASS
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Allow, FAIL
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: FAIL
+
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Allow, but rule suppressed, SKIP
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          guard:
+            SuppressedRules:
+            - SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Allow, but rule suppressed - CFN_NAG, SKIP
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F7
+              reason: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP
+
+- name: SQS QueuePolicy PolicyDocument with Effect:Allow, but rule suppressed - BOTH, SKIP
+  input: 
+    Resources: 
+      ExampleResource: 
+        Type: "AWS::SQS::QueuePolicy"
+        Properties:
+          Queues:
+          - foo-bar-baz
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              NotPrincipal: 
+                AWS:
+                - "arn:aws:iam::444455556666:user/Bob"
+                - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F7
+              reason: Suppressed for a very good reason
+          guard:
+            SuppressedRules:
+            - SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_ALLOW_PLUS_NOTPRINCIPAL: SKIP

--- a/rules/aws/amazon_sqs/tests/sqs_queuepolicy_no_wildcard_action_tests.yml
+++ b/rules/aws/amazon_sqs/tests/sqs_queuepolicy_no_wildcard_action_tests.yml
@@ -1,0 +1,193 @@
+###
+# SQS_QUEUEPOLICY_NO_WILDCARD_ACTION tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: SKIP
+
+- name: No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: SKIP
+
+- name: SQS QueuePolicy with Action <service:*, Effect:Deny, PASS
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:*" 
+                Effect: "Deny"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal:
+                  AWS:
+                    - "arn:aws:iam::444455556666:user/Bob"
+                    - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: PASS
+
+- name: SQS QueuePolicy with specific Actions, PASS
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:SendMessage" 
+                  - "SQS:ReceiveMessage"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal:
+                  AWS:
+                  - "arn:aws:iam::444455556666:user/Bob"
+                  - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: PASS
+
+- name: SQS QueuePolicy with Action *, Effect Allow, FAIL
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: "*"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal:
+                  AWS:
+                  - "arn:aws:iam::444455556666:user/Bob"
+                  - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: FAIL
+
+- name: SQS QueuePolicy with Action <service:*, Effect Allow, FAIL
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                - "SQS:*"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal:
+                  AWS:
+                  - "arn:aws:iam::444455556666:user/Bob"
+                  - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: FAIL
+
+- name: F20 CFN_NAG suppression, SKIP
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: "*"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal:
+                  AWS:
+                  - "arn:aws:iam::444455556666:user/Bob"
+                  - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F20
+              reason: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: SKIP
+
+- name: SQS_QUEUEPOLICY_NO_WILDCARD_ACTION Guard suppression, SKIP
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:*" 
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal:
+                  AWS:
+                  - "arn:aws:iam::444455556666:user/Bob"
+                  - "arn:aws:iam::444455556666:root"
+        Metadata:
+          guard:
+            SuppressedRules:
+            - SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: SKIP
+
+- name: F20 CFN_NAG & SQS_QUEUEPOLICY_NO_WILDCARD_ACTION Guard suppression, SKIP
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:*" 
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal:
+                  AWS:
+                  - "arn:aws:iam::444455556666:user/Bob"
+                  - "arn:aws:iam::444455556666:root"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F20
+              reason: Suppressed for a very good reason
+          guard:
+            SuppressedRules:
+            - SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_ACTION: SKIP

--- a/rules/aws/amazon_sqs/tests/sqs_queuepolicy_no_wildcard_principal_tests.yml
+++ b/rules/aws/amazon_sqs/tests/sqs_queuepolicy_no_wildcard_principal_tests.yml
@@ -1,0 +1,183 @@
+###
+# SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: SKIP
+
+- name: No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: SKIP
+
+- name: SQS QueuePolicy with Principal *, Effect:Deny, PASS
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:SendMessage" 
+                  - "SQS:ReceiveMessage"
+                Effect: "Deny"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal: "*" 
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: PASS
+
+- name: SQS QueuePolicy with specific Principals, PASS
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:SendMessage" 
+                  - "SQS:ReceiveMessage"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal:
+                  AWS:
+                  - "arn:aws:iam::444455556666:user/Bob"
+                  - "arn:aws:iam::444455556666:root"
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: PASS
+
+- name: SQS QueuePolicy with Principal *, Effect Allow, FAIL
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:SendMessage" 
+                  - "SQS:ReceiveMessage"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal: "*" 
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: FAIL
+
+- name: SQS QueuePolicy with Principal iam *, Effect Allow, FAIL
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:SendMessage" 
+                  - "SQS:ReceiveMessage"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal: "arn:aws:iam::*"
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: FAIL
+
+- name: F21 CFN_NAG suppression, SKIP
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:SendMessage" 
+                  - "SQS:ReceiveMessage"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal: "*" 
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F21
+              reason: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: SKIP
+
+- name: SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL Guard suppression, SKIP
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:SendMessage" 
+                  - "SQS:ReceiveMessage"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal: "*" 
+        Metadata:
+          guard:
+            SuppressedRules:
+            - SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: SKIP
+
+- name: F21 CFN_NAG & SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL Guard suppression, SKIP
+  input: 
+    Resources: 
+      SampleSQSPolicy: 
+        Type: AWS::SQS::QueuePolicy
+        Properties: 
+          Queues: 
+            - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+          PolicyDocument: 
+            Statement: 
+              - 
+                Action: 
+                  - "SQS:SendMessage" 
+                  - "SQS:ReceiveMessage"
+                Effect: "Allow"
+                Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+                Principal: "arn:aws:iam::*"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F21
+              reason: Suppressed for a very good reason
+          guard:
+            SuppressedRules:
+            - SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: Suppressed for a very good reason
+  expectations:
+    rules: 
+      SQS_QUEUEPOLICY_NO_WILDCARD_PRINCIPAL: SKIP


### PR DESCRIPTION
- Rules for AWS Sagemaker SNS and SQS resources to be migrated from cfn-nag to cfn-guard
- Added unit tests for each rule
