### PR TITLE
feat: Migrate KMS Microsoft_AD WAF CloudFront CloudWatch resources to cfn-guard Ruleset

### DIFF
--- a/rules/aws/aws_kms/cmk_backing_key_rotation_enabled.guard
+++ b/rules/aws/aws_kms/cmk_backing_key_rotation_enabled.guard
@@ -30,6 +30,8 @@
 #
 
 let cmk_backing_key_rotation_enabled = Resources.*[ Type == "AWS::KMS::Key"
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F19"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "CMK_BACKING_KEY_ROTATION_ENABLED"
 ]

--- a/rules/aws/aws_kms/kms_no_wildcard_principal.guard
+++ b/rules/aws/aws_kms/kms_no_wildcard_principal.guard
@@ -1,0 +1,51 @@
+#
+#####################################
+##         AWS Solutions           ##
+#####################################
+#
+# Rule Identifier:
+#    KMS_NO_WILDCARD_PRINCIPAL
+#
+# Description:
+#   KMS key should not allow * principal
+#
+# Reports on:
+#    AWS::KMS::Key
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# CFN-NAG Rule
+#    F76
+#
+# Documentation:
+#    https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+#
+# Scenarios:
+# a) SKIP: when there are no KMS CMKs
+# b) SKIP: when metada has rule suppression for KMS_NO_WILDCARD_PRINCIPAL
+# c) FAIL: when Principal: '*' appears in any KeyPolicy
+# d) PASS: when no keypolicy has Principle: '*'
+
+let kms_no_wildcard_principal = Resources.*[ Type == "AWS::KMS::Key"
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F76"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "KMS_NO_WILDCARD_PRINCIPAL"
+]
+
+rule KMS_NO_WILDCARD_PRINCIPAL when %kms_no_wildcard_principal !empty {
+  let violations = %kms_no_wildcard_principal[
+    some Properties.KeyPolicy.Statement[*] {
+      Principal == '*'
+    }
+  ]
+  %violations empty
+  <<
+    Violation: KMS key should not allow * principal.
+    Fix: Set the EnableKeyRotation property to true.
+  >>
+}

--- a/rules/aws/aws_kms/tests/kms_no_wildcard_principal_tests.yml
+++ b/rules/aws/aws_kms/tests/kms_no_wildcard_principal_tests.yml
@@ -1,31 +1,26 @@
 ###
-# CMK_BACKING_KEY_ROTATION_ENABLED tests
+# KMS_NO_WILDCARD_PRINCIPAL tests
 ###
 ---
 - name: Empty, SKIP
   input: {}
   expectations:
     rules:
-      CMK_BACKING_KEY_ROTATION_ENABLED: SKIP
+      KMS_NO_WILDCARD_PRINCIPAL: SKIP
 
 - name: Scenario a) No resources, SKIP
   input:
     Resources: {}
   expectations:
     rules:
-      CMK_BACKING_KEY_ROTATION_ENABLED: SKIP
+      KMS_NO_WILDCARD_PRINCIPAL: SKIP
 
-- name: Scenario b) EnableKeyRotation has been set to false but rule suppressed, SKIP
+- name: KMS key with principal "*", FAIL
   input:
     Resources:
-      myKMSKey:
+      KMS_NO_WILDCARD_PRINCIPAL:
         Type: AWS::KMS::Key
-        Metadata:
-          guard:
-            SuppressedRules:
-              - "CMK_BACKING_KEY_ROTATION_ENABLED"
         Properties:
-          EnableKeyRotation: false
           KeyPolicy:
             Statement:
               - Action: kms:*
@@ -37,13 +32,29 @@
                       - - 'arn:'
                         - Ref: AWS::Partition
                         - :iam::123456789012:root
-                Resource: '*'
+                Resource: 'arn:aws:iam::111122223333:foobar'
               - Action:
                   - kms:Decrypt
                   - kms:DescribeKey
                   - kms:Encrypt
                   - kms:ReEncrypt*
                   - kms:GenerateDataKey*
+                Effect: Allow
+                Principal: '*'
+                Resource: 'arn:aws:ec2:us-east-1:111122223333:foobar'
+  expectations:
+    rules:
+      KMS_NO_WILDCARD_PRINCIPAL: FAIL
+
+- name: KMS key with principal NOT "*", PASS
+  input:
+    Resources:
+      KMS_NO_WILDCARD_PRINCIPAL:
+        Type: AWS::KMS::Key
+        Properties:
+          KeyPolicy:
+            Statement:
+              - Action: kms:*
                 Effect: Allow
                 Principal:
                   AWS:
@@ -52,60 +63,69 @@
                       - - 'arn:'
                         - Ref: AWS::Partition
                         - :iam::123456789012:root
-                Resource: '*'
-            Version: "2012-10-17"
+                Resource: 'arn:aws:iam::111122223333:foobar'
+              - Action:
+                  - kms:Decrypt
+                  - kms:DescribeKey
+                  - kms:Encrypt
+                  - kms:ReEncrypt*
+                  - kms:GenerateDataKey*
+                Effect: Allow
+                Principal: 
+                  AWS:
+                    Fn::Join:
+                      - ""
+                      - - 'arn:'
+                        - Ref: AWS::Partition
+                        - :iam::123456789012:root
+                Resource: 'arn:aws:ec2:us-east-1:111122223333:foobar'
   expectations:
     rules:
-      CMK_BACKING_KEY_ROTATION_ENABLED: SKIP
+      KMS_NO_WILDCARD_PRINCIPAL: PASS
 
-- name: Scenario b) EnableKeyRotation has been set to false but rule suppressed - CFN_NAG, SKIP
+##
+## Suppressions
+##
+- name: F76 CFN-NAG suppression, SKIP
   input:
     Resources:
-      myKMSKey:
+      KMS_NO_WILDCARD_PRINCIPAL:
         Type: AWS::KMS::Key
+        Properties:
+          KeyPolicy:
+            Statement:
+              - Action: kms:*
+                Effect: Allow
+                Principal:
+                  AWS:
+                    Fn::Join:
+                      - ""
+                      - - 'arn:'
+                        - Ref: AWS::Partition
+                        - :iam::123456789012:root
+                Resource: 'arn:aws:iam::111122223333:foobar'
+              - Action:
+                  - kms:Decrypt
+                  - kms:DescribeKey
+                  - kms:Encrypt
+                  - kms:ReEncrypt*
+                  - kms:GenerateDataKey*
+                Effect: Allow
+                Principal: '*'
+                Resource: 'arn:aws:ec2:us-east-1:111122223333:foobar'
         Metadata:
           cfn_nag:
             rules_to_suppress:
-            - id: F19
+            - id: F76
               reason: Suppressed for a very good reason
-        Properties:
-          EnableKeyRotation: false
-          KeyPolicy:
-            Statement:
-              - Action: kms:*
-                Effect: Allow
-                Principal:
-                  AWS:
-                    Fn::Join:
-                      - ""
-                      - - 'arn:'
-                        - Ref: AWS::Partition
-                        - :iam::123456789012:root
-                Resource: '*'
-              - Action:
-                  - kms:Decrypt
-                  - kms:DescribeKey
-                  - kms:Encrypt
-                  - kms:ReEncrypt*
-                  - kms:GenerateDataKey*
-                Effect: Allow
-                Principal:
-                  AWS:
-                    Fn::Join:
-                      - ""
-                      - - 'arn:'
-                        - Ref: AWS::Partition
-                        - :iam::123456789012:root
-                Resource: '*'
-            Version: "2012-10-17"
   expectations:
     rules:
-      CMK_BACKING_KEY_ROTATION_ENABLED: SKIP
+      KMS_NO_WILDCARD_PRINCIPAL: SKIP
 
-- name: Scenario c) EnableKeyRotation has not been set, FAIL
+- name: cfn-guard suppression, SKIP
   input:
     Resources:
-      myKMSKey:
+      KMS_NO_WILDCARD_PRINCIPAL:
         Type: AWS::KMS::Key
         Properties:
           KeyPolicy:
@@ -119,7 +139,7 @@
                       - - 'arn:'
                         - Ref: AWS::Partition
                         - :iam::123456789012:root
-                Resource: '*'
+                Resource: 'arn:aws:iam::111122223333:foobar'
               - Action:
                   - kms:Decrypt
                   - kms:DescribeKey
@@ -127,26 +147,22 @@
                   - kms:ReEncrypt*
                   - kms:GenerateDataKey*
                 Effect: Allow
-                Principal:
-                  AWS:
-                    Fn::Join:
-                      - ""
-                      - - 'arn:'
-                        - Ref: AWS::Partition
-                        - :iam::123456789012:root
-                Resource: '*'
-            Version: "2012-10-17"
+                Principal: '*'
+                Resource: 'arn:aws:ec2:us-east-1:111122223333:foobar'
+        Metadata:
+          guard:
+            SuppressedRules:
+            - KMS_NO_WILDCARD_PRINCIPAL: Suppressed for a very good reason
   expectations:
     rules:
-      CMK_BACKING_KEY_ROTATION_ENABLED: FAIL
+      KMS_NO_WILDCARD_PRINCIPAL: SKIP
 
-- name: Scenario d) EnableKeyRotation is set to false, FAIL
+- name: cfn-guard and cfn-nag suppression, SKIP
   input:
     Resources:
-      myKMSKey:
+      KMS_NO_WILDCARD_PRINCIPAL:
         Type: AWS::KMS::Key
         Properties:
-          EnableKeyRotation: false
           KeyPolicy:
             Statement:
               - Action: kms:*
@@ -158,7 +174,7 @@
                       - - 'arn:'
                         - Ref: AWS::Partition
                         - :iam::123456789012:root
-                Resource: '*'
+                Resource: 'arn:aws:iam::111122223333:foobar'
               - Action:
                   - kms:Decrypt
                   - kms:DescribeKey
@@ -166,69 +182,16 @@
                   - kms:ReEncrypt*
                   - kms:GenerateDataKey*
                 Effect: Allow
-                Principal:
-                  AWS:
-                    Fn::Join:
-                      - ""
-                      - - 'arn:'
-                        - Ref: AWS::Partition
-                        - :iam::123456789012:root
-                Resource: '*'
-            Version: "2012-10-17"
+                Principal: '*'
+                Resource: 'arn:aws:ec2:us-east-1:111122223333:foobar'
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F76
+              reason: Suppressed for a very good reason
+          guard:
+            SuppressedRules:
+            - KMS_NO_WILDCARD_PRINCIPAL: Suppressed for a very good reason
   expectations:
     rules:
-      CMK_BACKING_KEY_ROTATION_ENABLED: FAIL
-
-- name: Scenario e) EnableKeyRotation is set to true, PASS
-  input:
-    Resources:
-      myKMSKey:
-        Type: AWS::KMS::Key
-        Properties:
-          EnableKeyRotation: true
-          KeyPolicy:
-            Statement:
-              - Action: kms:*
-                Effect: Allow
-                Principal:
-                  AWS:
-                    Fn::Join:
-                      - ""
-                      - - 'arn:'
-                        - Ref: AWS::Partition
-                        - :iam::123456789012:root
-                Resource: '*'
-              - Action:
-                  - kms:Decrypt
-                  - kms:DescribeKey
-                  - kms:Encrypt
-                  - kms:ReEncrypt*
-                  - kms:GenerateDataKey*
-                Effect: Allow
-                Principal:
-                  AWS:
-                    Fn::Join:
-                      - ""
-                      - - 'arn:'
-                        - Ref: AWS::Partition
-                        - :iam::123456789012:root
-                Resource: '*'
-              - Action:
-                  - kms:Decrypt
-                  - kms:DescribeKey
-                  - kms:Encrypt
-                  - kms:ReEncrypt*
-                  - kms:GenerateDataKey*
-                Effect: Allow
-                Principal:
-                  AWS:
-                    Fn::Join:
-                      - ""
-                      - - 'arn:'
-                        - Ref: AWS::Partition
-                        - :iam::123456789012:root
-                Resource: '*'
-            Version: "2012-10-17"
-  expectations:
-    rules:
-      CMK_BACKING_KEY_ROTATION_ENABLED: PASS
+      KMS_NO_WILDCARD_PRINCIPAL: SKIP

--- a/rules/aws/aws_microsoft_ad/microsoft_ad_no_plaintext_password.guard
+++ b/rules/aws/aws_microsoft_ad/microsoft_ad_no_plaintext_password.guard
@@ -1,0 +1,79 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#   MICROSOFT_AD_NO_PLAINTEXT_PASSWORD
+#
+# Description:
+#  Directory Service Microsoft AD password must not be a plaintext string or a Ref to a Parameter with a Default value.
+#  Can be Ref to a NoEcho Parameter without a Default, or a dynamic reference to a secretsmanager/ssm-secure value.
+#  with a Default value. Can be Ref to a NoEcho Parameter without a Default, or a dynamic reference to a secretsmanager value.
+#
+# Reports on:
+#   AWS::DirectoryService::MicrosoftAD
+#
+# Evaluates:
+#   AWS CloudFormation
+#
+# Rule Parameters:
+#   NA
+#
+# CFN_NAG Rule Id:
+#   F36
+#
+# Note: this rule works, however it sends the custom message twice for each resource
+#
+# Scenarios:
+# a) SKIP: when there are no AWS::DirectoryService::MicrosoftAD present
+# b) PASS: when all AWS::DirectoryService::MicrosoftAD use passwords from secure sources
+# c) FAIL: when any AWS::DirectoryService::MicrosoftAD has a Password property not using a secure source
+# d) SKIP: when metadata has rule suppression for MICROSOFT_AD_NO_PLAINTEXT_PASSWORD or CFN_NAG F36
+
+let microsoft_ad_no_plaintext_password = Resources.*[ Type == 'AWS::DirectoryService::MicrosoftAD'
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F36"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "MICROSOFT_AD_NO_PLAINTEXT_PASSWORD"
+]
+
+# Get any AWS::DirectoryService::MicrosoftAD Refs for Password?
+let microsoft_ad_password_refs = %microsoft_ad_no_plaintext_password.Properties.Password.'!Ref'
+
+# Rule 1: when Microsoft AD password no plaintext password have Ref to Parameter for Password
+rule MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER when
+  %microsoft_ad_no_plaintext_password not empty
+{
+  Parameters exists
+  Parameters not empty
+  %microsoft_ad_password_refs not empty
+  let parameter_refs = Parameters.%microsoft_ad_password_refs
+  when %parameter_refs !empty {
+    %parameter_refs.Type == 'String'
+    %parameter_refs.NoEcho exists
+    %parameter_refs.NoEcho == true
+    %parameter_refs.Default !exists
+  }
+}
+
+# Rule 2: when Microsoft AD password no plaintext password and above rule did not pass
+rule MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE when
+  %microsoft_ad_no_plaintext_password not empty
+  !MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER
+{
+  %microsoft_ad_no_plaintext_password.Properties.Password exists
+  %microsoft_ad_no_plaintext_password.Properties.Password in [ /{{resolve\:secretsmanager\:.*}}/, /{{resolve\:ssm-secure\:.*}}/ ]
+  <<
+    Violation: Microsoft AD Password Endpoint password must not be a plaintext string or a Ref to a Parameter with a Default value. Can be Ref to a NoEcho Parameter without a Default, or a dynamic reference to a secretsmanager value.
+    Fix: Replace plaintext value with a secure one.
+  >>
+}
+
+# One rule to rule them all...
+rule MICROSOFT_AD_NO_PLAINTEXT_PASSWORD when
+  %microsoft_ad_no_plaintext_password not empty
+{
+  MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER
+  OR
+  MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE
+}

--- a/rules/aws/aws_microsoft_ad/tests/microsoft_ad_no_plaintext_password_tests.yml
+++ b/rules/aws/aws_microsoft_ad/tests/microsoft_ad_no_plaintext_password_tests.yml
@@ -1,0 +1,305 @@
+###
+# MICROSOFT_AD_NO_PLAINTEXT_PASSWORD tests
+###
+---
+- name: Empty
+  input: {}
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: SKIP
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: SKIP
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: SKIP
+
+- name: Rule skips when no cluster present
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: SKIP
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: SKIP
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: SKIP
+
+- name: Plaintext password
+  input:
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: MasterPassword
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: FAIL
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: FAIL
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: FAIL
+
+- name: Password from Parameter w/ noEcho, no default value
+  input:
+    Parameters:
+      MyPassword:
+        Type: String
+        Description: Enter a password
+        MinLength: 8
+        NoEcho: true
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: !Ref MyPassword
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: PASS
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: SKIP
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: PASS
+
+- name: Password from Parameter w/ noEcho, default value
+  input:
+    Parameters:
+      MyPassword:
+        Type: String
+        Description: Enter a password
+        MinLength: 8
+        NoEcho: true
+        Default: foobarbaz
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: !Ref MyPassword
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: FAIL
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: FAIL
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: FAIL
+
+- name: Password from Parameter w/out noEcho, no default value
+  input:
+    Parameters:
+      MyPassword:
+        Type: String
+        Description: Enter a password
+        MinLength: 8
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: !Ref MyPassword
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: FAIL
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: FAIL
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: FAIL
+
+- name: Password from Parameter w/ noEcho = false, no default value
+  input:
+    Parameters:
+      MyPassword:
+        Type: String
+        Description: Enter a password
+        MinLength: 8
+        NoEcho: false
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: !Ref MyPassword
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: FAIL
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: FAIL
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: FAIL
+
+- name: Password is resolved from secretsmanager
+  input:
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: '{{resolve:secretsmanager:{$MyRDMSSecret}::password}}'
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: FAIL
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: PASS
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: PASS
+
+- name: Password is resolved from ssm-secure
+  input:
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: '{{resolve:ssm-secure:password}}'
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: FAIL
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: PASS
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: PASS
+
+- name: Password does not exists
+  input:
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: FAIL
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: FAIL
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: FAIL
+
+##
+## Suppression
+##
+- name: Plaintext password - F36 CFN_NAG Suppression
+  input:
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: MasterPassword
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F36
+              reason: Suppressed for a very good reason
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: SKIP
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: SKIP
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: SKIP
+
+- name: Plaintext password - Guard suppressed
+  input:
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: MasterPassword
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+        Metadata:
+          guard:
+            SuppressedRules:
+            - MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: Suppressed for a very good reason
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: SKIP
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: SKIP
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: SKIP
+
+- name: Plaintext password CFN_NAG and Guard suppressed
+  input:
+    Resources:
+      myDirectory:
+        Type: AWS::DirectoryService::MicrosoftAD
+        Properties:
+          Name: "corp.example.com"
+          Password: MasterPassword
+          ShortName:
+            Ref: MicrosoftADShortName
+          VpcSettings:
+            SubnetIds:
+              - Ref: subnetID1
+              - Ref: subnetID2
+            VpcId:
+              Ref: vpcID
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: F36
+                reason: Suppressed for a very good reason
+          guard:
+            SuppressedRules:
+            - MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: Suppressed for a very good reason
+  expectations:
+    rules:
+      MICROSOFT_AD_PASSWORD_USES_SECURE_PARAMETER: SKIP
+      MICROSOFT_AD_PASSWORD_USES_SECURE_SERVICE: SKIP
+      MICROSOFT_AD_NO_PLAINTEXT_PASSWORD: SKIP

--- a/rules/aws/aws_waf/tests/waf_web_acl_default_action_rule_tests.yml
+++ b/rules/aws/aws_waf/tests/waf_web_acl_default_action_rule_tests.yml
@@ -1,0 +1,198 @@
+###
+# WAF_WEB_ACL_DEFAULT_ACTION_RULE tests
+###
+---
+- name: Empty
+  input: {}
+  expectations:
+    rules:
+      WAF_WEB_ACL_DEFAULT_ACTION_RULE: SKIP
+
+- name: No resources
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      WAF_WEB_ACL_DEFAULT_ACTION_RULE: SKIP
+
+- name: WAF ACL Resource with DefaultAction as COUNT.
+  input:
+    Resources:
+      MyWebACL:
+        Type: "AWS::WAF::WebACL"
+        Properties:
+          Name: "WebACL to with three rules"
+          DefaultAction:
+            Type: "COUNT"
+          MetricName: "MyWebACL"
+          Rules:
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 1
+              RuleId:
+                Ref: "MyRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 2
+              RuleId:
+                Ref: "BadReferersRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 3
+              RuleId:
+                Ref: "SqlInjRule"
+  expectations:
+    rules:
+      WAF_WEB_ACL_DEFAULT_ACTION_RULE: PASS
+
+- name: WAF ACL Resource with DefaultAction as COUNT.
+  input:
+    Resources:
+      MyWebACL:
+        Type: "AWS::WAF::WebACL"
+        Properties:
+          Name: "WebACL to with three rules"
+          DefaultAction:
+            Type: "ALLOW"
+          MetricName: "MyWebACL"
+          Rules:
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 1
+              RuleId:
+                Ref: "MyRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 2
+              RuleId:
+                Ref: "BadReferersRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 3
+              RuleId:
+                Ref: "SqlInjRule"
+  expectations:
+    rules:
+      WAF_WEB_ACL_DEFAULT_ACTION_RULE: FAIL
+
+- name: CFN_NAG suppression for F665
+  input:
+    Resources:
+      MyWebACL:
+        Type: "AWS::WAF::WebACL"
+        Properties:
+          Name: "WebACL to with three rules"
+          DefaultAction:
+            Type: "ALLOW"
+          MetricName: "MyWebACL"
+          Rules:
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 1
+              RuleId:
+                Ref: "MyRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 2
+              RuleId:
+                Ref: "BadReferersRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 3
+              RuleId:
+                Ref: "SqlInjRule"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: F665
+                reason: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      WAF_WEB_ACL_DEFAULT_ACTION_RULE: SKIP
+
+- name: Guard suppression for WAF_WEB_ACL_DEFAULT_ACTION_RULE
+  input:
+    Resources:
+      MyWebACL:
+        Type: "AWS::WAF::WebACL"
+        Properties:
+          Name: "WebACL to with three rules"
+          DefaultAction:
+            Type: "ALLOW"
+          MetricName: "MyWebACL"
+          Rules:
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 1
+              RuleId:
+                Ref: "MyRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 2
+              RuleId:
+                Ref: "BadReferersRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 3
+              RuleId:
+                Ref: "SqlInjRule"
+        Metadata:
+          guard:
+            SuppressedRules:
+              - WAF_WEB_ACL_DEFAULT_ACTION_RULE
+  expectations:
+    rules:
+      WAF_WEB_ACL_DEFAULT_ACTION_RULE: SKIP
+
+- name: Guard and CFN_NAG suppression for F665 & WAF_WEB_ACL_DEFAULT_ACTION_RULE
+  input:
+    Resources:
+      MyWebACL:
+        Type: "AWS::WAF::WebACL"
+        Properties:
+          Name: "WebACL to with three rules"
+          DefaultAction:
+            Type: "ALLOW"
+          MetricName: "MyWebACL"
+          Rules:
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 1
+              RuleId:
+                Ref: "MyRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 2
+              RuleId:
+                Ref: "BadReferersRule"
+            -
+              Action:
+                Type: "BLOCK"
+              Priority: 3
+              RuleId:
+                Ref: "SqlInjRule"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: F665
+                reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+              - WAF_WEB_ACL_DEFAULT_ACTION_RULE
+  expectations:
+    rules:
+      WAF_WEB_ACL_DEFAULT_ACTION_RULE: SKIP

--- a/rules/aws/aws_waf/waf_web_acl_default_action_rule.guard
+++ b/rules/aws/aws_waf/waf_web_acl_default_action_rule.guard
@@ -1,0 +1,50 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#   WAF_WEB_ACL_DEFAULT_ACTION_RULE
+#
+# Description:
+#   WebAcl DefaultAction should not be ALLOW.
+#
+# Reports on:
+#   AWS::WAF::WebACL
+#
+# Evaluates:
+#   AWS CloudFormation
+#
+# Rule Parameters:
+#   NA
+#
+# CFN_NAG Rule Id:
+#   F665
+#
+# Scenarios:
+# a) SKIP: when there are no WAF ACL resources present.
+# b) PASS: when all WAF ACL resources do not have default action as allow.
+# c) FAIL: when any WAF ACL resources have default action as allow.
+# d) SKIP: when metadata has rule suppression for WAF_WEB_ACL_DEFAULT_ACTION_RULE or CFN_NAG F665
+
+#
+# Select all WAF ACL resources from incoming template (payload)
+#
+let waf_web_acl_default_action_rule = Resources.*[ Type == 'AWS::WAF::WebACL'
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F665"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "WAF_WEB_ACL_DEFAULT_ACTION_RULE"
+]
+
+rule WAF_WEB_ACL_DEFAULT_ACTION_RULE when %waf_web_acl_default_action_rule !empty {
+  let violation = %waf_web_acl_default_action_rule[
+    Type == 'AWS::WAF::WebACL'
+    Properties.DefaultAction.Type == 'ALLOW'
+  ]
+
+  %violation empty
+  <<
+    Violation: WAF ACL resources have default action as allow.
+    Fix: Change Default Action on WAF ACL resources.
+  >>
+}

--- a/rules/aws/cloudfront/cloudfront_accesslogs_enabled.guard
+++ b/rules/aws/cloudfront/cloudfront_accesslogs_enabled.guard
@@ -27,6 +27,8 @@
 # Select all CloudFront Distribution Resources from incoming template (payload)
 #
 let cloudfront_accesslogs_enabled_resources = Resources.*[ Type == 'AWS::CloudFront::Distribution'
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W10"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "CLOUDFRONT_ACCESSLOGS_ENABLED"
 ]

--- a/rules/aws/cloudfront/cloudfront_minimum_protocol_version_rule.guard
+++ b/rules/aws/cloudfront/cloudfront_minimum_protocol_version_rule.guard
@@ -1,0 +1,63 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#    CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE
+#
+# Description:
+#   Cloudfront should use minimum protocol version TLS 1.2.
+#
+# Reports on:
+#    AWS::CloudFront::Distribution
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# CFN_NAG Rule Id:
+#   W70
+#
+# Scenarios:
+# a) SKIP: when there are CloudFront Distribution resource present
+# b) PASS: When all CloudFront Distribution resources uses TLS 1.2
+# c) FAIL: When ANY CloudFront Distribution resources do not use TLS 1.2
+# d) SKIP: when metadata has rule suppression for CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE
+
+#
+# Select all CloudFront Distribution resources from incoming template (payload)
+#
+let cloudfront_minimum_protocol_version_rule = Resources.*[ Type == 'AWS::CloudFront::Distribution'
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W70"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE"
+]
+
+rule CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE when %cloudfront_minimum_protocol_version_rule !empty {
+  let violations = %cloudfront_minimum_protocol_version_rule[
+    Properties.DistributionConfig.ViewerCertificate !exists
+    OR
+    Properties.DistributionConfig {
+       ViewerCertificate.MinimumProtocolVersion !exists
+       OR
+       ViewerCertificate {
+        MinimumProtocolVersion is_string
+        MinimumProtocolVersion != /(?i)TLSv1.2/
+       }
+    }
+    OR
+    Properties.DistributionConfig.ViewerCertificate {
+       CloudFrontDefaultCertificate exists
+       CloudFrontDefaultCertificate == true
+    }
+  ]
+
+  %violations empty
+  <<
+    Violation: CloudFront Distribution resource do not use TLS 1.2 or viewerCertificate do no exist
+    Fix: Specify viewerCertificate and use TLS 1.2
+  >>
+}

--- a/rules/aws/cloudfront/tests/ cloudfront_accesslogs_enabled_tests.yml
+++ b/rules/aws/cloudfront/tests/ cloudfront_accesslogs_enabled_tests.yml
@@ -28,6 +28,20 @@
     rules:
       CLOUDFRONT_ACCESSLOGS_ENABLED: SKIP
 
+- name: Scenario b) Rule suppressed, SKIP
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W10
+              reason: Suppressed for a very good reason
+  expectations:
+    rules:
+      CLOUDFRONT_ACCESSLOGS_ENABLED: SKIP
+
 - name: Scenario c) Missing Distribution Config, FAIL
   input:
     Resources:

--- a/rules/aws/cloudfront/tests/cloudfront_minimum_protocol_version_rule_tests.yml
+++ b/rules/aws/cloudfront/tests/cloudfront_minimum_protocol_version_rule_tests.yml
@@ -1,0 +1,252 @@
+###
+# CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE tests
+###
+---
+- name: Empty
+  input: {}
+  expectations:
+    rules:
+      CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE: SKIP
+
+- name: No resources
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE: SKIP
+
+- name: CloudFront with viewerCertificate and TLS 1.2
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            CacheBehaviors:
+              - LambdaFunctionAssociations:
+                  - EventType: 'testString'
+                    LambdaFunctionARN: 'testString'
+            DefaultCacheBehavior:
+              LambdaFunctionAssociations:
+                - EventType: 'testString'
+                  LambdaFunctionARN: 'testString'
+            IPV6Enabled: true
+            Origins:
+              - CustomOriginConfig:
+                  OriginKeepaliveTimeout: 5
+                  OriginReadTimeout: 5
+            ViewerCertificate:
+              AcmCertificateArn: 'testArn'
+              CloudFrontDefaultCertificate: false
+              MinimumProtocolVersion: 'TLSv1.2-03-2008'
+              SslSupportMethod: 'POST'
+          Tags:
+            - Key: 'testString'
+              Value: 'testString'
+  expectations:
+    rules:
+      CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE: PASS
+
+- name: CloudFront with no viewerCertificate
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            CacheBehaviors:
+              - LambdaFunctionAssociations:
+                  - EventType: 'testString'
+                    LambdaFunctionARN: 'testString'
+            DefaultCacheBehavior:
+              LambdaFunctionAssociations:
+                - EventType: 'testString'
+                  LambdaFunctionARN: 'testString'
+            IPV6Enabled: true
+            Origins:
+              - CustomOriginConfig:
+                  OriginKeepaliveTimeout: 5
+                  OriginReadTimeout: 5
+          Tags:
+            - Key: 'testString'
+              Value: 'testString'
+  expectations:
+    rules:
+      CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE: FAIL
+
+- name: CloudFront with viewerCertificate and TLS 1.1
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            CacheBehaviors:
+              - LambdaFunctionAssociations:
+                  - EventType: 'testString'
+                    LambdaFunctionARN: 'testString'
+            DefaultCacheBehavior:
+              LambdaFunctionAssociations:
+                - EventType: 'testString'
+                  LambdaFunctionARN: 'testString'
+            IPV6Enabled: true
+            Origins:
+              - CustomOriginConfig:
+                  OriginKeepaliveTimeout: 5
+                  OriginReadTimeout: 5
+            ViewerCertificate:
+              AcmCertificateArn: 'testArn'
+              CloudFrontDefaultCertificate: true
+              MinimumProtocolVersion: 'TLSv1.1-03-2008'
+              SslSupportMethod: 'POST'
+          Tags:
+            - Key: 'testString'
+              Value: 'testString'
+  expectations:
+    rules:
+      CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE: FAIL
+
+- name: CloudFront with viewerCertificate and CloudFrontDefaultCertificate true
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            CacheBehaviors:
+              - LambdaFunctionAssociations:
+                  - EventType: 'testString'
+                    LambdaFunctionARN: 'testString'
+            DefaultCacheBehavior:
+              LambdaFunctionAssociations:
+                - EventType: 'testString'
+                  LambdaFunctionARN: 'testString'
+            IPV6Enabled: true
+            Origins:
+              - CustomOriginConfig:
+                  OriginKeepaliveTimeout: 5
+                  OriginReadTimeout: 5
+            ViewerCertificate:
+              AcmCertificateArn: 'testArn'
+              CloudFrontDefaultCertificate: true
+              MinimumProtocolVersion: 'TLSv1.2-03-2008'
+              SslSupportMethod: 'POST'
+          Tags:
+            - Key: 'testString'
+              Value: 'testString'
+  expectations:
+    rules:
+      CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE: FAIL
+
+- name: CFN_NAG suppression for W70
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            CacheBehaviors:
+              - LambdaFunctionAssociations:
+                  - EventType: 'testString'
+                    LambdaFunctionARN: 'testString'
+            DefaultCacheBehavior:
+              LambdaFunctionAssociations:
+                - EventType: 'testString'
+                  LambdaFunctionARN: 'testString'
+            IPV6Enabled: true
+            Origins:
+              - CustomOriginConfig:
+                  OriginKeepaliveTimeout: 5
+                  OriginReadTimeout: 5
+            ViewerCertificate:
+              AcmCertificateArn: 'testArn'
+              CloudFrontDefaultCertificate: false
+              MinimumProtocolVersion: 'TLSv1.2-03-2008'
+              SslSupportMethod: 'POST'
+          Tags:
+            - Key: 'testString'
+              Value: 'testString'
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W70
+              reason: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE: SKIP
+
+- name: Guard suppression for CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            CacheBehaviors:
+              - LambdaFunctionAssociations:
+                  - EventType: 'testString'
+                    LambdaFunctionARN: 'testString'
+            DefaultCacheBehavior:
+              LambdaFunctionAssociations:
+                - EventType: 'testString'
+                  LambdaFunctionARN: 'testString'
+            IPV6Enabled: true
+            Origins:
+              - CustomOriginConfig:
+                  OriginKeepaliveTimeout: 5
+                  OriginReadTimeout: 5
+            ViewerCertificate:
+              AcmCertificateArn: 'testArn'
+              CloudFrontDefaultCertificate: false
+              MinimumProtocolVersion: 'TLSv1.2-03-2008'
+              SslSupportMethod: 'POST'
+          Tags:
+            - Key: 'testString'
+              Value: 'testString'
+        Metadata:
+          guard:
+            SuppressedRules:
+            - CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE
+  expectations:
+    rules:
+      CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE: SKIP
+
+- name: Guard and CFN_NAG suppression for W70 & CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE
+  input:
+    Resources:
+      CloudFrontDistribution:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+          DistributionConfig:
+            CacheBehaviors:
+              - LambdaFunctionAssociations:
+                  - EventType: 'testString'
+                    LambdaFunctionARN: 'testString'
+            DefaultCacheBehavior:
+              LambdaFunctionAssociations:
+                - EventType: 'testString'
+                  LambdaFunctionARN: 'testString'
+            IPV6Enabled: true
+            Origins:
+              - CustomOriginConfig:
+                  OriginKeepaliveTimeout: 5
+                  OriginReadTimeout: 5
+            ViewerCertificate:
+              AcmCertificateArn: 'testArn'
+              CloudFrontDefaultCertificate: false
+              MinimumProtocolVersion: 'TLSv1.2-03-2008'
+              SslSupportMethod: 'POST'
+          Tags:
+            - Key: 'testString'
+              Value: 'testString'
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W70
+              reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+            - CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE
+  expectations:
+    rules:
+      CLOUDFRONT_MINIMUM_PROTOCOL_VERSION_RULE: SKIP

--- a/rules/aws/cloudwatch/cloudwatch_log_group_encrypted.guard
+++ b/rules/aws/cloudwatch/cloudwatch_log_group_encrypted.guard
@@ -28,6 +28,8 @@
 # Select all cloudwatch logs log group resources from incoming template (payload)
 #
 let cloudwatch_logs = Resources.*[ Type == 'AWS::Logs::LogGroup'
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W84"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "CLOUDWATCH_LOG_GROUP_ENCRYPTED"
 ]

--- a/rules/aws/cloudwatch/cw_loggroup_retention_period_check.guard
+++ b/rules/aws/cloudwatch/cw_loggroup_retention_period_check.guard
@@ -28,6 +28,8 @@
 # Select all cloudwatch logs log group resources from incoming template (payload)
 #
 let cloudwatch_logs_retention_period = Resources.*[ Type == 'AWS::Logs::LogGroup'
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W86"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "CW_LOGGROUP_RETENTION_PERIOD_CHECK"
 ]

--- a/rules/aws/cloudwatch/tests/cloudwatch_log_group_encrypted_tests.yml
+++ b/rules/aws/cloudwatch/tests/cloudwatch_log_group_encrypted_tests.yml
@@ -52,3 +52,19 @@
   expectations:
     rules:
       CLOUDWATCH_LOG_GROUP_ENCRYPTED: SKIP
+
+- name: CloudWatch Log LogGroup missing KmsKeyId but rule suppressed, SKIP
+  input:
+    Resources:
+      ExampleLogGroup:
+        Type: AWS::Logs::LogGroup
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W84
+              reason: Suppressed for a very good reason
+        Properties:
+          LogGroupName: myLogGroup
+  expectations:
+    rules:
+      CLOUDWATCH_LOG_GROUP_ENCRYPTED: SKIP

--- a/rules/aws/cloudwatch/tests/cw_loggroup_retention_period_check_tests.yml
+++ b/rules/aws/cloudwatch/tests/cw_loggroup_retention_period_check_tests.yml
@@ -62,3 +62,19 @@
   expectations:
     rules:
       CW_LOGGROUP_RETENTION_PERIOD_CHECK: SKIP
+
+- name: CloudWatch Log LogGroup missing RetentionInDays but rule suppressed, SKIP
+  input:
+    Resources:
+      ExampleLogGroup:
+        Type: AWS::Logs::LogGroup
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W86
+              reason: Suppressed for a very good reason
+        Properties:
+          LogGroupName: myLogGroup
+  expectations:
+    rules:
+      CW_LOGGROUP_RETENTION_PERIOD_CHECK: SKIP


### PR DESCRIPTION
- Rules for AWS KMS Microsoft_AD WAF CloudFront CloudWatch resources to be migrated from cfn-nag to cfn-guard
- Added unit tests for each rule