### PR TITLE
feat: Migrate AWS cfn-authentication lambda opensource_service secrets_manager resources to cfn-guard ruleset

### DIFF
--- a/rules/aws/all_resources/cfn_authentication_rule.guard
+++ b/rules/aws/all_resources/cfn_authentication_rule.guard
@@ -1,0 +1,58 @@
+#
+#####################################
+##          AWS Solutions          ##
+#####################################
+# Rule Identifier:
+#    CFN_AUTHENTICATION_RULE
+#
+# Description:
+#   Specifying credentials in the template itself is probably not the safest thing.
+#
+# Reports on:
+#    All Resources
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# CFN_NAG Rule Id:
+#   W1
+#
+# Scenarios:
+# a) SKIP: when there are no resource present
+# b) PASS: When no resources specifies credentials in template.
+# c) FAIL: When any resource specifies credentials in template.
+# d) SKIP: when metadata has rule suppression for CFN_AUTHENTICATION_RULE
+
+#
+# Select all Security Group resources from incoming template (payload)
+#
+let cfn_authentication_rule = Resources.Metadata
+let skip_cfn_authentication = %cfn_authentication_rule[
+      "AWS::CloudFormation::Authentication" exists
+      Metadata.cfn_nag.rules_to_suppress not exists or
+      Metadata.cfn_nag.rules_to_suppress.*.id != "W1"
+      Metadata.guard.SuppressedRules not exists or
+      Metadata.guard.SuppressedRules.* != "CFN_AUTHENTICATION_RULE"
+]
+
+rule CFN_AUTHENTICATION_RULE when
+    %cfn_authentication_rule !empty
+    %skip_cfn_authentication !empty
+ {
+  let violation = %cfn_authentication_rule[
+    "AWS::CloudFormation::Authentication".*.accessKeyId exists
+    OR
+    "AWS::CloudFormation::Authentication".*.password exists
+    OR
+    "AWS::CloudFormation::Authentication".*.secretKey exists
+  ]
+
+  %violation empty
+  <<
+    Violation: CFN template has sensitive credentials defined.
+    Fix: Remove sensitive credentials.
+  >>
+}

--- a/rules/aws/all_resources/tests/cfn_authentication_rule_tests.yml
+++ b/rules/aws/all_resources/tests/cfn_authentication_rule_tests.yml
@@ -1,0 +1,279 @@
+###
+# CFN_AUTHENTICATION_RULE tests
+###
+---
+- name: Empty
+  input: {}
+  expectations:
+    rules:
+      CFN_AUTHENTICATION_RULE: SKIP
+
+- name: No resources
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      CFN_AUTHENTICATION_RULE: SKIP
+
+- name: CFN Insensitive authentication
+  input:
+    Resources:
+        RootRole:
+          Type: "AWS::IAM::Role"
+          Properties:
+           AssumeRolePolicyDocument:
+             Version: "2012-10-17"
+             Statement:
+               - Effect: "Allow"
+                 Principal:
+                   Service:
+                     - "ec2.amazonaws.com"
+                   AWS: "arn:aws:iam::324320755747:root"
+                 Action:
+                   - "sts:AssumeRole"
+        EC2I4LBA1:
+          Type: "AWS::EC2::Instance"
+          Properties:
+            ImageId: "ami-6df1e514"
+            InstanceType: "t2.micro"
+            SubnetId:
+              "Ref": "subnetId"
+        Metadata:
+          Type: AWS::CloudFormation::Authentication
+          AWS::CloudFormation::Authentication:
+            testS3:
+              type: "s3"
+              roleName: !Ref RootRole
+              buckets:
+                - "somebucket333"
+  expectations:
+    rules:
+      CFN_AUTHENTICATION_RULE: PASS
+
+- name: CFN Sensitive authentication
+  input:
+    Resources:
+      RootRole:
+        Type: "AWS::IAM::Role"
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Principal:
+                  Service:
+                    - "ec2.amazonaws.com"
+                  AWS: "arn:aws:iam::324320755747:root"
+                Action:
+                  - "sts:AssumeRole"
+      EC2I4LBA1:
+        Type: "AWS::EC2::Instance"
+        Properties:
+          ImageId: "ami-6df1e514"
+          InstanceType: "t2.micro"
+          SubnetId:
+            "Ref": "subnetId"
+      Metadata:
+        Type: AWS::CloudFormation::Authentication
+        AWS::CloudFormation::Authentication:
+          testBasic:
+            type: "basic"
+            username: "testUsername1"
+            password: "sensitive_password"
+            uris:
+              - "http://www.example.com/test"
+  expectations:
+    rules:
+      CFN_AUTHENTICATION_RULE: FAIL
+
+- name: CFN does not contains Metadata Resource
+  input:
+    Resources:
+        RootRole:
+          Type: "AWS::IAM::Role"
+          Properties:
+           AssumeRolePolicyDocument:
+             Version: "2012-10-17"
+             Statement:
+               - Effect: "Allow"
+                 Principal:
+                   Service:
+                     - "ec2.amazonaws.com"
+                   AWS: "arn:aws:iam::324320755747:root"
+                 Action:
+                   - "sts:AssumeRole"
+        EC2I4LBA1:
+          Type: "AWS::EC2::Instance"
+          Properties:
+            ImageId: "ami-6df1e514"
+            InstanceType: "t2.micro"
+            SubnetId:
+              "Ref": "subnetId"
+  expectations:
+    rules:
+      CFN_AUTHENTICATION_RULE: SKIP
+
+- name: CFN_NAG suppression for W1
+  input:
+    Resources:
+      RootRole:
+        Type: "AWS::IAM::Role"
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Principal:
+                  Service:
+                    - "ec2.amazonaws.com"
+                  AWS: "arn:aws:iam::324320755747:root"
+                Action:
+                  - "sts:AssumeRole"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W1
+                reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+              - CFN_AUTHENTICATION_RULE
+      EC2I4LBA1:
+        Type: "AWS::EC2::Instance"
+        Properties:
+          ImageId: "ami-6df1e514"
+          InstanceType: "t2.micro"
+          SubnetId:
+            "Ref": "subnetId"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W1
+                reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+              - CFN_AUTHENTICATION_RULE
+      Metadata:
+        Type: AWS::CloudFormation::Authentication
+        AWS::CloudFormation::Authentication:
+          testBasic:
+            type: "basic"
+            username: "testUsername1"
+            password: "sensitive_password"
+            uris:
+              - "http://www.example.com/test"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W1
+                reason: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      CFN_AUTHENTICATION_RULE: SKIP
+
+- name: Guard suppression for CFN_AUTHENTICATION_RULE
+  input:
+    Resources:
+      RootRole:
+        Type: "AWS::IAM::Role"
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Principal:
+                  Service:
+                    - "ec2.amazonaws.com"
+                  AWS: "arn:aws:iam::324320755747:root"
+                Action:
+                  - "sts:AssumeRole"
+        Metadata:
+          guard:
+            SuppressedRules:
+              - CFN_AUTHENTICATION_RULE
+      EC2I4LBA1:
+        Type: "AWS::EC2::Instance"
+        Properties:
+          ImageId: "ami-6df1e514"
+          InstanceType: "t2.micro"
+          SubnetId:
+            "Ref": "subnetId"
+        Metadata:
+          guard:
+            SuppressedRules:
+              - CFN_AUTHENTICATION_RULE
+      Metadata:
+        Type: AWS::CloudFormation::Authentication
+        AWS::CloudFormation::Authentication:
+          testBasic:
+            type: "basic"
+            username: "testUsername1"
+            password: "sensitive_password"
+            uris:
+              - "http://www.example.com/test"
+        Metadata:
+          guard:
+            SuppressedRules:
+              - CFN_AUTHENTICATION_RULE
+  expectations:
+    rules:
+      CFN_AUTHENTICATION_RULE: SKIP
+
+- name: Guard and CFN_NAG suppression for W1 & CFN_AUTHENTICATION_RULE
+  input:
+    Resources:
+      RootRole:
+        Type: "AWS::IAM::Role"
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Principal:
+                  Service:
+                    - "ec2.amazonaws.com"
+                  AWS: "arn:aws:iam::324320755747:root"
+                Action:
+                  - "sts:AssumeRole"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W1
+                reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+              - CFN_AUTHENTICATION_RULE
+      EC2I4LBA1:
+        Type: "AWS::EC2::Instance"
+        Properties:
+          ImageId: "ami-6df1e514"
+          InstanceType: "t2.micro"
+          SubnetId:
+            "Ref": "subnetId"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W1
+                reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+              - CFN_AUTHENTICATION_RULE
+      Metadata:
+        Type: AWS::CloudFormation::Authentication
+        AWS::CloudFormation::Authentication:
+          testBasic:
+            type: "basic"
+            username: "testUsername1"
+            password: "sensitive_password"
+            uris:
+              - "http://www.example.com/test"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W1
+                reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+              - CFN_AUTHENTICATION_RULE
+  expectations:
+    rules:
+      CFN_AUTHENTICATION_RULE: SKIP

--- a/rules/aws/lambda/lambda_concurrency_check.guard
+++ b/rules/aws/lambda/lambda_concurrency_check.guard
@@ -27,6 +27,8 @@
 # Select all AWS Lambda Function resources from incoming template (payload)
 #
 let aws_lambda_functions_concurrency = Resources.*[ Type == 'AWS::Lambda::Function' 
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W92"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "LAMBDA_CONCURRENCY_CHECK"
 ]

--- a/rules/aws/lambda/lambda_inside_vpc.guard
+++ b/rules/aws/lambda/lambda_inside_vpc.guard
@@ -27,6 +27,8 @@
 # Select all AWS Lambda Function resources from incoming template (payload)
 #
 let aws_lambda_functions_inside_vpc = Resources.*[ Type == 'AWS::Lambda::Function' 
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W89"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "LAMBDA_INSIDE_VPC"
 ]

--- a/rules/aws/lambda/lambda_no_wildcard_principal.guard
+++ b/rules/aws/lambda/lambda_no_wildcard_principal.guard
@@ -1,0 +1,51 @@
+#
+#####################################
+##         AWS Solutions           ##
+#####################################
+# Rule Identifier:
+#    LAMBDA_NO_WILDCARD_PRINCIPALS
+#
+# Description:
+#    Checks if the AWS Lambda permission uses open principal
+#
+# Reports on:
+#    AWS::Lambda::Permission
+#    AWS::Lambda::LayerVersionPermission
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# CFN_NAG Rule Id:
+#   F13
+#
+# Scenarios:
+# a) SKIP: when no AWS Lambda permission policies are present
+# b) PASS: when no AWS Lambda permission policies allow all principals
+# c) FAIL: when any AWS Lambda permission allows all principals
+# d) SKIP: hen metadata includes the suppression for rule LAMBDA_NO_WILDCARD_PRINCIPALS
+
+let applicable_types = [
+  "AWS::Lambda::Permission",
+  "AWS::Lambda::LayerVersionPermission"
+]
+
+let lambda_no_wildcard_principal = Resources.*[ Type in %applicable_types
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "F13"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "LAMBDA_NO_WILDCARD_PRINCIPALS"
+]
+
+rule LAMBDA_NO_WILDCARD_PRINCIPALS when %lambda_no_wildcard_principal !empty {
+  let violations = %lambda_no_wildcard_principal[
+    Properties.Principal == '*'
+  ]
+  %violations empty
+  <<
+    Violation: Lambda permission principal should not be wildcard.
+    Fix: Specify principal or a list of principals.
+  >>
+}

--- a/rules/aws/lambda/lambda_permission_invoke_function_action.guard
+++ b/rules/aws/lambda/lambda_permission_invoke_function_action.guard
@@ -1,0 +1,49 @@
+#
+#####################################
+##         AWS Solutions           ##
+#####################################
+# Rule Identifier:
+#    LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION
+#
+# Description:
+#    Checks if the AWS Lambda permission uses any other action apart from 'lambda:InvokeFunction'
+#
+# Reports on:
+#    AWS::Lambda::Permission
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# CFN_NAG Rule Id:
+#   W24
+#
+# Scenarios:
+# a) SKIP: when no AWS Lambda permission policies are present
+# b) PASS: when no AWS Lambda permission uses any other action apart from 'lambda:InvokeFunction'
+# c) FAIL: when any AWS Lambda permission allows action apart from 'lambda:InvokeFunction'
+# d) SKIP: When metadata includes the suppression for rule LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION
+
+let applicable_types = [
+  "AWS::Lambda::Permission"
+]
+
+let lambda_permission_invoke_function_action = Resources.*[ Type in %applicable_types
+  Metadata.cfn_nag.rules_to_suppress not exists or
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W24"
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION"
+]
+
+rule LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION when %lambda_permission_invoke_function_action !empty {
+  let violations = %lambda_permission_invoke_function_action[
+    some Properties.Action != 'lambda:InvokeFunction'
+  ]
+  %violations empty
+  <<
+    Violation: Lambda permission beside InvokeFunction might not be what you want.
+    Fix: Remove Actions beside 'lambda:InvokeFunction'.
+  >>
+}

--- a/rules/aws/lambda/tests/lambda_concurrency_check_tests.yml
+++ b/rules/aws/lambda/tests/lambda_concurrency_check_tests.yml
@@ -77,3 +77,22 @@
   expectations:
     rules:
       LAMBDA_CONCURRENCY_CHECK: SKIP
+
+- name: AWS Lambda Function reserved concurrent execution limit NOT set but rule suppressed, SKIP
+  input:
+    Resources:
+      ExampleLambda-1:
+        Type: "AWS::Lambda::Function"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W92
+              reason: Suppressed for a very good reason
+        Properties: 
+          Role: arn:aws:iam::123456789012:role/lambda-role
+          Code:
+            S3Bucket: my-bucket
+            S3Key: function.zip
+  expectations:
+    rules:
+      LAMBDA_CONCURRENCY_CHECK: SKIP

--- a/rules/aws/lambda/tests/lambda_inside_vpc_tests.yml
+++ b/rules/aws/lambda/tests/lambda_inside_vpc_tests.yml
@@ -66,3 +66,22 @@
   expectations:
     rules:
       LAMBDA_INSIDE_VPC: SKIP
+
+- name: AWS Lambda function VPC Configuration NOT set but rule suppressed, SKIP
+  input:
+    Resources:
+      ExampleLambda:
+        Type: "AWS::Lambda::Function"
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W89
+              reason: Suppressed for a very good reason
+        Properties: 
+          Role: arn:aws:iam::123456789012:role/lambda-role
+          Code:
+            S3Bucket: my-bucket
+            S3Key: function.zip
+  expectations:
+    rules:
+      LAMBDA_INSIDE_VPC: SKIP

--- a/rules/aws/lambda/tests/lambda_no_wildcard_principal_tests.yml
+++ b/rules/aws/lambda/tests/lambda_no_wildcard_principal_tests.yml
@@ -1,0 +1,142 @@
+###
+# LAMBDA_NO_WILDCARD_PRINCIPALS tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      LAMBDA_NO_WILDCARD_PRINCIPALS: SKIP
+
+- name: No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      LAMBDA_NO_WILDCARD_PRINCIPALS: SKIP
+
+- name: Lambda permission policy limited to an account as the principal, PASS
+  input:
+    Resources:
+      ExampleLambdaPermission1: 
+        Type: "AWS::Lambda::Permission"
+        Properties: 
+          Action: lambda:InvokeFunction
+          FunctionName: test-function
+          Principal: 111122223333
+      ExampleLambdaPermission2: 
+        Type: "AWS::Lambda::Permission"
+        Properties: 
+          Action: lambda:InvokeFunction
+          FunctionName: test-function
+          Principal: "123456789012"
+      ExampleLambdaPermission3: 
+        Type: "AWS::Lambda::Permission"
+        Properties: 
+          Action: lambda:InvokeFunction
+          FunctionName: test-function
+          Principal: !Ref AWS::AccountId
+  expectations:
+    rules:
+      LAMBDA_NO_WILDCARD_PRINCIPALS: PASS
+
+- name: Lambda permission policy limited to a service (not S3) as the principal scoped to a principal organization, PASS
+  input:
+    Resources:
+      ExampleLambdaPermission-1: 
+        Type: "AWS::Lambda::Permission"
+        Properties: 
+          Action: lambda:InvokeFunction
+          FunctionName: test-function
+          Principal: sns.amazonaws.com
+          PrincipalOrgID: o-aa111bb222
+  expectations:
+    rules:
+      LAMBDA_NO_WILDCARD_PRINCIPALS: PASS
+
+- name: Lambda permission policy not limited, FAIL
+  input:
+    Resources:
+      ExampleLambdaPermission1: 
+        Type: "AWS::Lambda::Permission"
+        Properties: 
+          Action: lambda:InvokeFunction
+          FunctionName: test-function
+          Principal: '*'
+          SourceAccount: 123456789012
+  expectations:
+    rules:
+      LAMBDA_NO_WILDCARD_PRINCIPALS: FAIL
+
+- name: Lambda layer version permission policy limited to an organization, FAIL
+  input:
+    Resources:
+      ExampleLambdaLayerVersionPermission: 
+        Type: "AWS::Lambda::LayerVersionPermission"
+        Properties: 
+          Action: lambda:GetLayerVersion
+          LayerVersionArn: arn:aws:lambda:us-west-2:123456789012:layer:my-layer:1
+          Principal: "*"
+          OrganizationId: o-aa111bb222
+  expectations:
+    rules:
+      LAMBDA_NO_WILDCARD_PRINCIPALS: FAIL
+
+- name: CFN_NAG suppression for F13, SKIP
+  input:
+    Resources:
+      ExampleLambdaLayerVersionPermission: 
+        Type: "AWS::Lambda::LayerVersionPermission"
+        Properties: 
+          Action: lambda:GetLayerVersion
+          LayerVersionArn: arn:aws:lambda:us-west-2:123456789012:layer:my-layer:1
+          Principal: "*"
+          OrganizationId: o-aa111bb222
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F13
+              reason: Suppressed for a very good reason
+  expectations:
+    rules:
+      LAMBDA_NO_WILDCARD_PRINCIPALS: SKIP
+
+- name: Guard suppression for LAMBDA_NO_WILDCARD_PRINCIPALS, SKIP
+  input:
+    Resources:
+      ExampleLambdaLayerVersionPermission: 
+        Type: "AWS::Lambda::LayerVersionPermission"
+        Properties: 
+          Action: lambda:GetLayerVersion
+          LayerVersionArn: arn:aws:lambda:us-west-2:123456789012:layer:my-layer:1
+          Principal: "*"
+          OrganizationId: o-aa111bb222
+        Metadata:
+          guard:
+            SuppressedRules:
+            - LAMBDA_NO_WILDCARD_PRINCIPALS
+  expectations:
+    rules:
+      LAMBDA_NO_WILDCARD_PRINCIPALS: SKIP
+
+- name: Guard and CFN_NAG suppression for F13 & LAMBDA_NO_WILDCARD_PRINCIPALS, SKIP
+  input:
+    Resources:
+      ExampleLambdaLayerVersionPermission: 
+        Type: "AWS::Lambda::LayerVersionPermission"
+        Properties: 
+          Action: lambda:GetLayerVersion
+          LayerVersionArn: arn:aws:lambda:us-west-2:123456789012:layer:my-layer:1
+          Principal: "*"
+          OrganizationId: o-aa111bb222
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: F13
+              reason: Suppressed for a very good reason
+          guard:
+            SuppressedRules:
+            - LAMBDA_NO_WILDCARD_PRINCIPALS
+  expectations:
+    rules:
+      LAMBDA_NO_WILDCARD_PRINCIPALS: SKIP

--- a/rules/aws/lambda/tests/lambda_permission_invoke_function_action_tests.yml
+++ b/rules/aws/lambda/tests/lambda_permission_invoke_function_action_tests.yml
@@ -1,0 +1,131 @@
+###
+# LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION tests
+###
+---
+- name: Empty
+  input: {}
+  expectations:
+    rules:
+      LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION: SKIP
+
+- name: No resources
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION: SKIP
+
+- name: Lambda permission policy with only invokeFunction actions
+  input:
+    Resources:
+      ExampleLambdaPermission1:
+        Type: "AWS::Lambda::Permission"
+        Properties:
+          Action: lambda:InvokeFunction
+          FunctionName: test-function
+          Principal: 111122223333
+      ExampleLambdaPermission2:
+        Type: "AWS::Lambda::Permission"
+        Properties:
+          Action: lambda:InvokeFunction
+          FunctionName: test-function
+          Principal: "123456789012"
+      ExampleLambdaPermission3:
+        Type: "AWS::Lambda::Permission"
+        Properties:
+          Action: lambda:InvokeFunction
+          FunctionName: test-function
+          Principal: !Ref AWS::AccountId
+  expectations:
+    rules:
+      LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION: PASS
+
+- name: Lambda permission action is lambda:GetFunction
+  input:
+    Resources:
+      ExampleLambdaPermission1:
+        Type: "AWS::Lambda::Permission"
+        Properties:
+          Action: lambda:GetFunction
+          FunctionName: test-function
+          Principal: 111122223333
+          SourceAccount: 123456789012
+  expectations:
+    rules:
+      LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION: FAIL
+
+- name: Lambda permission actions are lambda:GetFunction and lambda:InvokeFunction
+  input:
+    Resources:
+      ExampleLambdaPermission1:
+        Type: "AWS::Lambda::Permission"
+        Properties:
+          Action: [
+            lambda:InvokeFunction,
+            lambda:GetFunction
+          ]
+          FunctionName: test-function
+          Principal: 111122223333
+          SourceAccount: 123456789012
+  expectations:
+    rules:
+      LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION: FAIL
+
+- name: CFN_NAG suppression for W24
+  input:
+    Resources:
+      ExampleLambdaPermission:
+        Type: "AWS::Lambda::Permission"
+        Properties:
+          Action: lambda:GetFunction
+          Principal: 111122223333
+          FunctionName: test-function
+          OrganizationId: o-aa111bb222
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W24
+              reason: Suppressed to test suppression works and skips this test
+  expectations:
+    rules:
+      LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION: SKIP
+
+- name: Guard suppression for LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION
+  input:
+    Resources:
+      ExampleLambdaPermission:
+        Type: "AWS::Lambda::Permission"
+        Properties:
+          Action: lambda:GetFunction
+          Principal: 111122223333
+          FunctionName: test-function
+          OrganizationId: o-aa111bb222
+        Metadata:
+          guard:
+            SuppressedRules:
+            - LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION
+  expectations:
+    rules:
+      LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION: SKIP
+
+- name: Guard and CFN_NAG suppression for W24 & LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION
+  input:
+    Resources:
+      ExampleLambdaPermission:
+        Type: "AWS::Lambda::Permission"
+        Properties:
+          Action: lambda:GetFunction
+          Principal: 111122223333
+          FunctionName: test-function
+          OrganizationId: o-aa111bb222
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W24
+              reason: Suppressed to test suppression works and skips this test
+          guard:
+            SuppressedRules:
+            - LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION
+  expectations:
+    rules:
+      LAMBDA_PERMISSION_INVOKE_FUNCTION_ACTION: SKIP

--- a/rules/aws/opensearch_service/elasticsearch_encrypted_at_rest.guard
+++ b/rules/aws/opensearch_service/elasticsearch_encrypted_at_rest.guard
@@ -28,6 +28,8 @@
 # Select all elasticsearch domains from incoming template
 #
 let elasticsearch_domains_encrypted = Resources.*[ Type == "AWS::Elasticsearch::Domain"
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W54"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "ELASTICSEARCH_ENCRYPTED_AT_REST"
 ]

--- a/rules/aws/opensearch_service/elasticsearch_in_vpc_only.guard
+++ b/rules/aws/opensearch_service/elasticsearch_in_vpc_only.guard
@@ -27,6 +27,8 @@
 # Select all elasticsearch domains from incoming template
 #
 let elasticsearch_domains_vpc_required = Resources.*[ Type == "AWS::Elasticsearch::Domain"
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W90"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "ELASTICSEARCH_IN_VPC_ONLY"
 ]

--- a/rules/aws/opensearch_service/opensearch_node_to_node_encryption_check.guard
+++ b/rules/aws/opensearch_service/opensearch_node_to_node_encryption_check.guard
@@ -28,6 +28,8 @@
 # Select all elasticsearch domains from incoming template
 #
 let opensearch_node_to_node_encryption_check = Resources.*[ Type == "AWS::OpenSearchService::Domain"
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W85"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "OPENSEARCH_NODE_TO_NODE_ENCRYPTION_CHECK"
 ]

--- a/rules/aws/opensearch_service/tests/elasticsearch_encrypted_at_rest_tests.yml
+++ b/rules/aws/opensearch_service/tests/elasticsearch_encrypted_at_rest_tests.yml
@@ -30,6 +30,22 @@
     rules:
       ELASTICSEARCH_ENCRYPTED_AT_REST: SKIP
 
+- name: Scenario b) Rule fails when ElasticSearch domain has server side encryption property missing but rule suppressed, SKIP
+  input:
+    Resources:
+      ElasticsearchDomain:
+        Type: AWS::Elasticsearch::Domain
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W54
+              reason: Suppressed for a very good reason
+        Properties:
+          DomainName: test
+  expectations:
+    rules:
+      ELASTICSEARCH_ENCRYPTED_AT_REST: SKIP
+
 - name: Scenario c) Rule fails when ElasticSearch domain has server side encryption property missing, FAIL
   input:
     Resources:

--- a/rules/aws/opensearch_service/tests/elasticsearch_in_vpc_only_tests.yml
+++ b/rules/aws/opensearch_service/tests/elasticsearch_in_vpc_only_tests.yml
@@ -30,6 +30,22 @@
     rules:
       ELASTICSEARCH_IN_VPC_ONLY: SKIP
 
+- name: Scenario b) Rule fails when ElasticSearch domain does not have VPCOptions property but rule suppressed - CFN_NAG, SKIP
+  input:
+    Resources:
+      ElasticsearchDomain:
+        Type: AWS::Elasticsearch::Domain
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W90
+              reason: Suppressed for a very good reason
+        Properties:
+          DomainName: test
+  expectations:
+    rules:
+      ELASTICSEARCH_IN_VPC_ONLY: SKIP
+
 - name: Scenario c) Rule fails when ElasticSearch domain does not have VPCOptions property, FAIL
   input:
     Resources:

--- a/rules/aws/opensearch_service/tests/opensearch_node_to_node_encryption_check_tests.yml
+++ b/rules/aws/opensearch_service/tests/opensearch_node_to_node_encryption_check_tests.yml
@@ -30,6 +30,22 @@
     rules:
       OPENSEARCH_NODE_TO_NODE_ENCRYPTION_CHECK: SKIP
 
+- name: Scenario b) Rule fails when OpenSearchService domain has Node-to-Node Encryption property missing but rule suppressed - CFN_NAG, SKIP
+  input:
+    Resources:
+      OpenSearchDomain:
+        Type: AWS::OpenSearchService::Domain
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W85
+              reason: Suppressed for a very good reason
+        Properties:
+          DomainName: test
+  expectations:
+    rules:
+      OPENSEARCH_NODE_TO_NODE_ENCRYPTION_CHECK: SKIP
+
 - name: Scenario c) Rule fails when OpenSearchService domain has Node-to-Node Encryption property missing
   input:
     Resources:

--- a/rules/aws/secrets_manager/secretsmanager_using_cmk.guard
+++ b/rules/aws/secrets_manager/secretsmanager_using_cmk.guard
@@ -28,6 +28,8 @@
 # Select all AWS::SageMaker::EndpointConfig resources from incoming template (payload)
 #
 let aws_secretsmanager_secret_cmk = Resources.*[ Type == "AWS::SecretsManager::Secret"
+  Metadata.cfn_nag.rules_to_suppress not exists or 
+  Metadata.cfn_nag.rules_to_suppress.*.id != "W77"
   Metadata.guard.SuppressedRules not exists or
   Metadata.guard.SuppressedRules.* != "SECRETSMANAGER_USING_CMK"
 ]

--- a/rules/aws/secrets_manager/tests/secretsmanager_using_cmk_tests.yml
+++ b/rules/aws/secrets_manager/tests/secretsmanager_using_cmk_tests.yml
@@ -126,3 +126,35 @@
   expectations:
     rules:
       SECRETSMANAGER_USING_CMK: SKIP
+
+- name: rule suppressed - CFN_NAG, SKIP
+  input:
+    Resources:
+      MySecret:
+        Type: 'AWS::SecretsManager::Secret'
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+            - id: W77
+              reason: Suppressed for a very good reason
+        Properties:
+          Name: MySecretForAppA
+          Description: "This secret has a dynamically generated secret password."
+          GenerateSecretString:
+            SecretStringTemplate: '{"username": "test-user"}'
+            GenerateStringKey: "password"
+            PasswordLength: 30
+            ExcludeCharacters: '"@/\'
+          KmsKeyId: alias/aws/secretsmanager
+      MySecretRotationSchedule:
+        Type: AWS::SecretsManager::RotationSchedule
+        Properties:
+          SecretId:
+            Ref: MySecret
+          RotationLambdaARN:
+            Ref: MyCustomRotationLambda
+          RotationRules:
+            AutomaticallyAfterDays: 30
+  expectations:
+    rules:
+      SECRETSMANAGER_USING_CMK: SKIP


### PR DESCRIPTION
- Rules for AWS cfn-authentication lambda opensource_service secrets_managerresources to be migrated from cfn-nag to cfn-guard
- Added unit tests for each rule
