### PR TITLE
chore: Make "all rules" build more repeatable

### DIFF
--- a/mappings/build.py
+++ b/mappings/build.py
@@ -18,7 +18,7 @@ def create_guard_rules_registry_all_rules(dirName, version):
     controls = ["all rules in AWS Guard Rules Registry"]
     mappings = []
     resource_list = download_resource_type_list()
-    for build_file in glob.iglob(aws_rules_directory, recursive=True):
+    for build_file in sorted(glob.iglob(aws_rules_directory, recursive=True)):
       reports_on = []
       build_file_relative_path = os.path.relpath(build_file)
       for resource in resource_list:


### PR DESCRIPTION
Building from the same rules twice can would generate different files.

By sorting the inputs we make sure that only content changes trigger output changes

I haven't had the chance to test this, but the change seems small

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
